### PR TITLE
Fix/ Maps Incompatible

### DIFF
--- a/src/game/WorldHandlers/GridMap.cpp
+++ b/src/game/WorldHandlers/GridMap.cpp
@@ -32,7 +32,7 @@
 #include <mutex>
 
 char const* MAP_MAGIC         = "MAPS";
-char const* MAP_VERSION_MAGIC = "c1.4";
+char const* MAP_VERSION_MAGIC = "c1.5";
 char const* MAP_AREA_MAGIC    = "AREA";
 char const* MAP_HEIGHT_MAGIC  = "MHGT";
 char const* MAP_LIQUID_MAGIC  = "MLIQ";


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Maps Error Fixed

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->
2022-07-21 13:44:19 ERROR:Map file './Data/maps/00004331.map' is non-compatible version created with a different map-extractor version.
2022-07-21 13:44:19 ERROR:Correct .map files not found in path './Data/maps' or.vmtree/.vmtile files in './Data/vmaps'. Please place.map and vmap files in appropriate directories or correct the DataDir value in the worldserver.conf file.
