### PR TITLE
Fix (Command/Error) nonexistent command / subcommand

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1658517995568089400.sql
+++ b/data/sql/updates/pending_db_world/rev_1658517995568089400.sql
@@ -1,0 +1,1 @@
+DELETE FROM `command` WHERE `command_text` IN ('flusharenapoints', 'modify scale', 'npc addmove', 'wp import');


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
### Changes proposed

- Commands that cause error, when trying to create a character by console.

### Issues addressed
<!-- If your fix has a relating issue, link it below -->

- Closes

### SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

```
Table `command` have nonexistent command 'flusharenapoints', skip.
Table `command` have unexpected subcommand 'scale' in command 'modify scale', skip.
Table `command` have unexpected subcommand 'addmove' in command 'npc addmove', skip.
Table `command` have unexpected subcommand 'import' in command 'wp import', skip.
```

### Tests performed
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- Windows 10
- In console

### How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Use the command: `account create user pass`.
2. You will see the message on the console.

### Known issues and TODO list
<!-- Is there anything else left to do after this PR? -->

---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
