### PR TITLE
Implement LootTypeId Loading & Merge loot tables into single table

### DIFF
--- a/sql/updates/world/4.3.4/2022_08_06_00_world_loot_merge.sql
+++ b/sql/updates/world/4.3.4/2022_08_06_00_world_loot_merge.sql
@@ -1,0 +1,93 @@
+--
+-- 
+
+DROP TABLE IF EXISTS world_loot_template;
+CREATE TABLE world_loot_template (
+    `Entry` mediumint(8) unsigned NOT NULL DEFAULT 0,
+    `lootTypeId` tinyint(3) unsigned NOT NULL,
+    `Item` mediumint(8) unsigned NOT NULL DEFAULT 0,
+    `Reference` mediumint(8) unsigned NOT NULL DEFAULT 0,
+    `Chance` float NOT NULL DEFAULT 100,
+    `QuestRequired` tinyint(1) NOT NULL DEFAULT 0,
+    `LootMode` smallint(5) unsigned NOT NULL DEFAULT 1,
+    `GroupId` tinyint(3) unsigned NOT NULL DEFAULT 0,
+    `MinCount` tinyint(3) unsigned NOT NULL DEFAULT 1,
+    `MaxCount` tinyint(3) unsigned NOT NULL DEFAULT 1,
+    `Comment` varchar(255) DEFAULT NULL,
+    PRIMARY KEY (`Entry`, `lootTypeId`, `Item`),
+    KEY `Entry` (`Entry`, `lootTypeId`)
+  ) ENGINE = MyISAM DEFAULT CHARSET = utf8mb4 COMMENT = 'Loot System';
+
+-- creature loot
+INSERT INTO world_loot_template (Entry, lootTypeId, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount)
+SELECT Entry, 1, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount
+    FROM creature_loot_template ORDER BY Entry ASC;
+
+-- disenchant loot
+INSERT INTO world_loot_template (Entry, lootTypeId, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount)
+SELECT Entry, 2, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount
+    FROM disenchant_loot_template ORDER BY Entry ASC;
+
+-- fishing loot
+INSERT INTO world_loot_template (Entry, lootTypeId, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount)
+SELECT Entry, 3, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount
+    FROM fishing_loot_template ORDER BY Entry ASC;
+
+-- gameobject loot
+INSERT INTO world_loot_template (Entry, lootTypeId, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount)
+SELECT Entry, 4, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount
+    FROM gameobject_loot_template ORDER BY Entry ASC;    
+
+-- item loot
+INSERT INTO world_loot_template (Entry, lootTypeId, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount)
+SELECT Entry, 5, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount
+    FROM item_loot_template ORDER BY Entry ASC;
+
+-- mail loot
+INSERT INTO world_loot_template (Entry, lootTypeId, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount)
+SELECT Entry, 6, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount
+    FROM mail_loot_template ORDER BY Entry ASC;
+
+-- milling loot
+INSERT INTO world_loot_template (Entry, lootTypeId, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount)
+SELECT Entry, 7, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount
+    FROM milling_loot_template ORDER BY Entry ASC;
+
+-- pickpocketing loot
+INSERT INTO world_loot_template (Entry, lootTypeId, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount)
+SELECT Entry, 8, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount
+    FROM pickpocketing_loot_template ORDER BY Entry ASC;
+
+-- prospecting loot
+INSERT INTO world_loot_template (Entry, lootTypeId, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount)
+SELECT Entry, 9, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount
+    FROM prospecting_loot_template ORDER BY Entry ASC;
+
+-- reference loot
+INSERT INTO world_loot_template (Entry, lootTypeId, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount)
+SELECT Entry, 10, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount
+    FROM reference_loot_template ORDER BY Entry ASC;
+    
+-- skinning loot
+INSERT INTO world_loot_template (Entry, lootTypeId, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount)
+SELECT Entry, 11, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount
+    FROM skinning_loot_template ORDER BY Entry ASC;
+    
+-- spell loot
+INSERT INTO world_loot_template (Entry, lootTypeId, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount)
+SELECT Entry, 12, Item, Reference, Chance, QuestRequired, LootMode, GroupId, MinCount, MaxCount
+    FROM spell_loot_template ORDER BY Entry ASC;
+
+-- drop old loot tables
+DROP TABLE creature_loot_template;
+DROP TABLE disenchant_loot_template;
+DROP TABLE fishing_loot_template;
+DROP TABLE gameobject_loot_template;
+DROP TABLE item_loot_template;
+DROP TABLE mail_loot_template;
+DROP TABLE milling_loot_template;
+DROP TABLE pickpocketing_loot_template;
+DROP TABLE prospecting_loot_template;
+DROP TABLE reference_loot_template;
+DROP TABLE skinning_loot_template;
+DROP TABLE spell_loot_template;

--- a/src/server/game/AuctionHouseBot/AuctionHouseBotSeller.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBotSeller.cpp
@@ -75,18 +75,7 @@ bool AuctionBotSeller::Initialize()
     LOG_DEBUG("ahbot", "Npc vendor filter has %u items", (uint32)npcItems.size());
 
     LOG_DEBUG("ahbot", "Loading loot items for filter..");
-    QueryResult result = WorldDatabase.PQuery(
-        "SELECT `item` FROM `creature_loot_template` WHERE `Reference` = 0 UNION "
-        "SELECT `item` FROM `disenchant_loot_template` WHERE `Reference` = 0 UNION "
-        "SELECT `item` FROM `fishing_loot_template` WHERE `Reference` = 0 UNION "
-        "SELECT `item` FROM `gameobject_loot_template` WHERE `Reference` = 0 UNION "
-        "SELECT `item` FROM `item_loot_template` WHERE `Reference` = 0 UNION "
-        "SELECT `item` FROM `milling_loot_template` WHERE `Reference` = 0 UNION "
-        "SELECT `item` FROM `pickpocketing_loot_template` WHERE `Reference` = 0 UNION "
-        "SELECT `item` FROM `prospecting_loot_template` WHERE `Reference` = 0 UNION "
-        "SELECT `item` FROM `reference_loot_template` WHERE `Reference` = 0 UNION "
-        "SELECT `item` FROM `skinning_loot_template` WHERE `Reference` = 0 UNION "
-        "SELECT `item` FROM `spell_loot_template` WHERE `Reference` = 0");
+    QueryResult result = WorldDatabase.PQuery("SELECT `item` FROM `world_loot_template` WHERE `Reference` = 0");
 
     if (result)
     {

--- a/src/server/game/Loot/Loot.h
+++ b/src/server/game/Loot/Loot.h
@@ -134,6 +134,23 @@ enum LootSlotType
     LOOT_SLOT_TYPE_OWNER        = 4                         // ignore binding confirmation and etc, for single player looting
 };
 
+enum LootTypeId
+{
+    LOOT_TYPE_NONE            = -1,
+    LOOT_TYPE_CREATURE        = 1,
+    LOOT_TYPE_DISENCHANT      = 2,
+    LOOT_TYPE_FISHING         = 3,
+    LOOT_TYPE_GAMEOBJECT      = 4,
+    LOOT_TYPE_ITEM            = 5,
+    LOOT_TYPE_MAIL            = 6,
+    LOOT_TYPE_MILLING         = 7,
+    LOOT_TYPE_PICKPOCKETING   = 8,
+    LOOT_TYPE_PROSPECTING     = 9,
+    LOOT_TYPE_REFERENCE       = 10,
+    LOOT_TYPE_SKINNING        = 11,
+    LOOT_TYPE_SPELL           = 12
+};
+
 struct FC_GAME_API LootItem
 {
     uint32  itemid;

--- a/src/server/game/Loot/LootMgr.h
+++ b/src/server/game/Loot/LootMgr.h
@@ -68,13 +68,13 @@ class FC_GAME_API LootStore
 
         virtual ~LootStore() { Clear(); }
 
-        void Verify() const;
+        void Verify(LootTypeId lootTypeId) const;
 
-        uint32 LoadAndCollectLootIds(LootIdSet& ids_set);
-        void CheckLootRefs(LootIdSet* ref_set = nullptr) const; // check existence reference and remove it from ref_set
-        void ReportUnusedIds(LootIdSet const& ids_set) const;
-        void ReportNonExistingId(uint32 lootId) const;
-        void ReportNonExistingId(uint32 lootId, char const* ownerType, uint32 ownerId) const;
+        uint32 LoadAndCollectLootIds(LootIdSet& ids_set, LootTypeId lootTypeId);
+        void CheckLootRefs(LootTypeId lootTypeId, LootIdSet* ref_set = nullptr) const; // check existence reference and remove it from ref_set
+        void ReportUnusedIds(LootIdSet const& ids_set, LootTypeId lootTypeId) const;
+        void ReportNonExistingId(uint32 lootId, LootTypeId lootTypeId) const;
+        void ReportNonExistingId(uint32 lootId, char const* ownerType, uint32 ownerId, LootTypeId lootTypeId) const;
 
         bool HaveLootFor(uint32 loot_id) const { return m_LootTemplates.find(loot_id) != m_LootTemplates.end(); }
         bool HaveQuestLootFor(uint32 loot_id) const;
@@ -88,7 +88,7 @@ class FC_GAME_API LootStore
         char const* GetEntryName() const { return m_entryName; }
         bool IsRatesAllowed() const { return m_ratesAllowed; }
     protected:
-        uint32 LoadLootTable();
+        uint32 LoadLootTable(LootTypeId);
         void Clear();
     private:
         LootTemplateMap m_LootTemplates;
@@ -119,8 +119,8 @@ class FC_GAME_API LootTemplate
         bool HasQuestDropForPlayer(LootTemplateMap const& store, Player const* player, uint8 groupId = 0) const;
 
         // Checks integrity of the template
-        void Verify(LootStore const& store, uint32 Id) const;
-        void CheckLootRefs(LootTemplateMap const& store, LootIdSet* ref_set) const;
+        void Verify(LootStore const& store, uint32 Id, LootTypeId lootTypeId) const;
+        void CheckLootRefs(LootTemplateMap const& store, LootTypeId, LootIdSet* ref_set) const;
         bool addConditionItem(Condition* cond);
         bool isReference(uint32 id);
 

--- a/src/server/scripts/Commands/cs_reload.cpp
+++ b/src/server/scripts/Commands/cs_reload.cpp
@@ -554,16 +554,6 @@ public:
         return true;
     }
 
-    static bool HandleReloadLootTemplatesCreatureCommand(ChatHandler* handler, char const* /*args*/)
-    {
-        LOG_INFO("misc", "Re-Loading Loot Tables... (`creature_loot_template`)");
-        LoadLootTemplates_Creature();
-        LootTemplates_Creature.CheckLootRefs();
-        handler->SendGlobalGMSysMessage("DB table `creature_loot_template` reloaded.");
-        sConditionMgr->LoadConditions(true);
-        return true;
-    }
-
     static bool HandleReloadCreatureMovementOverrideCommand(ChatHandler* handler, char const* /*args*/)
     {
         LOG_INFO("misc", "Re-Loading Creature movement overrides...");
@@ -572,111 +562,122 @@ public:
         return true;
     }
 
+    static bool HandleReloadLootTemplatesCreatureCommand(ChatHandler* handler, char const* /*args*/)
+    {
+        LOG_INFO("misc", "Re-Loading Loot Tables LootType 1 (Creature)...");
+        LoadLootTemplates_Creature();
+        LootTemplates_Creature.CheckLootRefs(LOOT_TYPE_CREATURE);
+        handler->SendGlobalGMSysMessage("DB table `world_loot_template` reloaded for Creature.");
+        sConditionMgr->LoadConditions(true);
+        return true;
+    }
+
     static bool HandleReloadLootTemplatesDisenchantCommand(ChatHandler* handler, char const* /*args*/)
     {
-        LOG_INFO("misc", "Re-Loading Loot Tables... (`disenchant_loot_template`)");
+        LOG_INFO("misc", "Re-Loading Loot Tables LootType 2 (Disenchant)...");
         LoadLootTemplates_Disenchant();
-        LootTemplates_Disenchant.CheckLootRefs();
-        handler->SendGlobalGMSysMessage("DB table `disenchant_loot_template` reloaded.");
+        LootTemplates_Disenchant.CheckLootRefs(LOOT_TYPE_DISENCHANT);
+        handler->SendGlobalGMSysMessage("DB table `world_loot_template` reloaded for Disenchant.");
         sConditionMgr->LoadConditions(true);
         return true;
     }
 
     static bool HandleReloadLootTemplatesFishingCommand(ChatHandler* handler, char const* /*args*/)
     {
-        LOG_INFO("misc", "Re-Loading Loot Tables... (`fishing_loot_template`)");
+        LOG_INFO("misc", "Re-Loading Loot Tables LootType 3 (Fishing)...");
         LoadLootTemplates_Fishing();
-        LootTemplates_Fishing.CheckLootRefs();
-        handler->SendGlobalGMSysMessage("DB table `fishing_loot_template` reloaded.");
+        LootTemplates_Fishing.CheckLootRefs(LOOT_TYPE_FISHING);
+        handler->SendGlobalGMSysMessage("DB table `world_loot_template` reloaded for Fishing.");
         sConditionMgr->LoadConditions(true);
         return true;
     }
 
     static bool HandleReloadLootTemplatesGameobjectCommand(ChatHandler* handler, char const* /*args*/)
     {
-        LOG_INFO("misc", "Re-Loading Loot Tables... (`gameobject_loot_template`)");
+        LOG_INFO("misc", "Re-Loading Loot Tables LootType 4 (GameObject)...");
         LoadLootTemplates_Gameobject();
-        LootTemplates_Gameobject.CheckLootRefs();
-        handler->SendGlobalGMSysMessage("DB table `gameobject_loot_template` reloaded.");
+        LootTemplates_Gameobject.CheckLootRefs(LOOT_TYPE_GAMEOBJECT);
+        handler->SendGlobalGMSysMessage("DB table `world_loot_template` reloaded for GameObject.");
         sConditionMgr->LoadConditions(true);
         return true;
     }
 
     static bool HandleReloadLootTemplatesItemCommand(ChatHandler* handler, char const* /*args*/)
     {
-        LOG_INFO("misc", "Re-Loading Loot Tables... (`item_loot_template`)");
+        LOG_INFO("misc", "Re-Loading Loot Tables LootType 5 (Item)...");
         LoadLootTemplates_Item();
-        LootTemplates_Item.CheckLootRefs();
-        handler->SendGlobalGMSysMessage("DB table `item_loot_template` reloaded.");
-        sConditionMgr->LoadConditions(true);
-        return true;
-    }
-
-    static bool HandleReloadLootTemplatesMillingCommand(ChatHandler* handler, char const* /*args*/)
-    {
-        LOG_INFO("misc", "Re-Loading Loot Tables... (`milling_loot_template`)");
-        LoadLootTemplates_Milling();
-        LootTemplates_Milling.CheckLootRefs();
-        handler->SendGlobalGMSysMessage("DB table `milling_loot_template` reloaded.");
-        sConditionMgr->LoadConditions(true);
-        return true;
-    }
-
-    static bool HandleReloadLootTemplatesPickpocketingCommand(ChatHandler* handler, char const* /*args*/)
-    {
-        LOG_INFO("misc", "Re-Loading Loot Tables... (`pickpocketing_loot_template`)");
-        LoadLootTemplates_Pickpocketing();
-        LootTemplates_Pickpocketing.CheckLootRefs();
-        handler->SendGlobalGMSysMessage("DB table `pickpocketing_loot_template` reloaded.");
-        sConditionMgr->LoadConditions(true);
-        return true;
-    }
-
-    static bool HandleReloadLootTemplatesProspectingCommand(ChatHandler* handler, char const* /*args*/)
-    {
-        LOG_INFO("misc", "Re-Loading Loot Tables... (`prospecting_loot_template`)");
-        LoadLootTemplates_Prospecting();
-        LootTemplates_Prospecting.CheckLootRefs();
-        handler->SendGlobalGMSysMessage("DB table `prospecting_loot_template` reloaded.");
+        LootTemplates_Item.CheckLootRefs(LOOT_TYPE_ITEM);
+        handler->SendGlobalGMSysMessage("DB table `world_loot_template` reloaded for Item.");
         sConditionMgr->LoadConditions(true);
         return true;
     }
 
     static bool HandleReloadLootTemplatesMailCommand(ChatHandler* handler, char const* /*args*/)
     {
-        LOG_INFO("misc", "Re-Loading Loot Tables... (`mail_loot_template`)");
+        LOG_INFO("misc", "Re-Loading Loot Tables LootType 6 (Mail)...");
         LoadLootTemplates_Mail();
-        LootTemplates_Mail.CheckLootRefs();
-        handler->SendGlobalGMSysMessage("DB table `mail_loot_template` reloaded.");
+        LootTemplates_Mail.CheckLootRefs(LOOT_TYPE_MAIL);
+        handler->SendGlobalGMSysMessage("DB table `world_loot_template` reloaded for Mail.");
+        sConditionMgr->LoadConditions(true);
+        return true;
+    }
+
+    static bool HandleReloadLootTemplatesMillingCommand(ChatHandler* handler, char const* /*args*/)
+    {
+        LOG_INFO("misc", "Re-Loading Loot Tables LootType 7 (Milling)...");
+        LoadLootTemplates_Milling();
+        LootTemplates_Milling.CheckLootRefs(LOOT_TYPE_MILLING);
+        handler->SendGlobalGMSysMessage("DB table `world_loot_template` reloaded for Milling.");
+        sConditionMgr->LoadConditions(true);
+        return true;
+    }
+
+    static bool HandleReloadLootTemplatesPickpocketingCommand(ChatHandler* handler, char const* /*args*/)
+    {
+        LOG_INFO("misc", "Re-Loading Loot Tables LootType 8 (PickPocketing)...");
+        LoadLootTemplates_Pickpocketing();
+        LootTemplates_Pickpocketing.CheckLootRefs(LOOT_TYPE_PICKPOCKETING);
+        handler->SendGlobalGMSysMessage("DB table `world_loot_template` reloaded for PickPocketing.");
+        sConditionMgr->LoadConditions(true);
+        return true;
+    }
+
+    static bool HandleReloadLootTemplatesProspectingCommand(ChatHandler* handler, char const* /*args*/)
+    {
+        LOG_INFO("misc", "Re-Loading Loot Tables LootType 9 (Prospecting)...");
+        LoadLootTemplates_Prospecting();
+        LootTemplates_Prospecting.CheckLootRefs(LOOT_TYPE_PROSPECTING);
+        handler->SendGlobalGMSysMessage("DB table `world_loot_template` reloaded for Prospecting.");
         sConditionMgr->LoadConditions(true);
         return true;
     }
 
     static bool HandleReloadLootTemplatesReferenceCommand(ChatHandler* handler, char const* /*args*/)
     {
-        LOG_INFO("misc", "Re-Loading Loot Tables... (`reference_loot_template`)");
+        LOG_INFO("misc", "Re-Loading Loot Tables LootType 10 (Reference)...");
         LoadLootTemplates_Reference();
-        handler->SendGlobalGMSysMessage("DB table `reference_loot_template` reloaded.");
+        LootTemplates_Reference.CheckLootRefs(LOOT_TYPE_REFERENCE);
+        handler->SendGlobalGMSysMessage("DB table `world_loot_template` reloaded for reference.");
         sConditionMgr->LoadConditions(true);
         return true;
     }
 
     static bool HandleReloadLootTemplatesSkinningCommand(ChatHandler* handler, char const* /*args*/)
     {
-        LOG_INFO("misc", "Re-Loading Loot Tables... (`skinning_loot_template`)");
+        LOG_INFO("misc", "Re-Loading Loot Tables LootType 11 (Skinning)...");
         LoadLootTemplates_Skinning();
-        LootTemplates_Skinning.CheckLootRefs();
-        handler->SendGlobalGMSysMessage("DB table `skinning_loot_template` reloaded.");
+        LootTemplates_Skinning.CheckLootRefs(LOOT_TYPE_SKINNING);
+        handler->SendGlobalGMSysMessage("DB table `world_loot_template` reloaded for Skinning.");
         sConditionMgr->LoadConditions(true);
         return true;
     }
 
     static bool HandleReloadLootTemplatesSpellCommand(ChatHandler* handler, char const* /*args*/)
     {
-        LOG_INFO("misc", "Re-Loading Loot Tables... (`spell_loot_template`)");
+        LOG_INFO("misc", "Re-Loading Loot Tables LootType 12 (Spell)...");
         LoadLootTemplates_Spell();
-        LootTemplates_Spell.CheckLootRefs();
-        handler->SendGlobalGMSysMessage("DB table `spell_loot_template` reloaded.");
+        LootTemplates_Spell.CheckLootRefs(LOOT_TYPE_SPELL);
+        handler->SendGlobalGMSysMessage("DB table `world_loot_template` reloaded for Spell.");
         sConditionMgr->LoadConditions(true);
         return true;
     }


### PR DESCRIPTION
**Changes proposed**:

- Merge all loot tables into a single table
- Assign each loot template their own LootTypeId

**Loot Type Identifiers**:
```code
LOOT_TYPE_NONE            = -1,

LOOT_TYPE_CREATURE        = 1,
LOOT_TYPE_DISENCHANT      = 2,
LOOT_TYPE_FISHING         = 3,
LOOT_TYPE_GAMEOBJECT      = 4,
LOOT_TYPE_ITEM            = 5,
LOOT_TYPE_MAIL            = 6,
LOOT_TYPE_MILLING         = 7,
LOOT_TYPE_PICKPOCKETING   = 8,
LOOT_TYPE_PROSPECTING     = 9,
LOOT_TYPE_REFERENCE       = 10,
LOOT_TYPE_SKINNING        = 11,
LOOT_TYPE_SPELL           = 12
```
These identifiers are attached when data is selected and inserted into the new table.

**Example Query**:
```sql
SELECT * FROM world_loot_template WHERE lootTypeId = 1 AND Item = 2070; -- Darnassian Bleu
```
This will list all items under the loot type for creature for item Darnassian Bleu. 

**New Table Structure**:

![image](https://user-images.githubusercontent.com/5354732/183253122-9d520aeb-62e3-4bbf-b704-e038d1508532.png)

The structure remains the same as the old tables, although a new entry **lootTypeId** is added after **Entry**.

**Tests performed**: (Does it build, tested in-game, etc)

Builds and tested in-game

**Known issues and TODO list**:

- [ ] Improvements based on feedback

**Note**:

SQL file coming later as it is being written. Feedback is welcome, as some changes may be required.
