### PR TITLE
(Core/WorldSocket) SQL query correction

### DIFF
--- a/src/server/game/Server/WorldSocket.cpp
+++ b/src/server/game/Server/WorldSocket.cpp
@@ -293,9 +293,9 @@ struct AccountInfo {
     Locale = LocaleConstant(fields[7].GetUInt8());
     Recruiter = fields[8].GetUInt32();
     OS = fields[9].GetString();
-    Security = AccountTypes(fields[11].GetUInt8());
-    IsBanned = fields[13].GetUInt64() != 0;
-    IsRecruiter = fields[14].GetUInt32() != 0;
+    Security = AccountTypes(fields[10].GetUInt8());
+    IsBanned = fields[11].GetUInt64() != 0;
+    //IsRecruiter = fields[14].GetUInt32() != 0;
 
     uint32 world_expansion = sWorld->getIntConfig(CONFIG_EXPANSION);
     if (Expansion > world_expansion) Expansion = world_expansion;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
### Changes proposed

- When doing the SQL query, you are getting values which are null. Since the query goes from 0 to 12.
- That causes, that in Windows at least, the values are null, and in that way, it has no way to corroborate, if the account is banned or not, so it does not enter the game.

### Issues addressed
<!-- If your fix has a relating issue, link it below -->

- Closes

### SOURCE:
<!-- If you can, include a source that can strengthen your claim -->


### Tests performed
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- Windows 10
- In-game

### How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Apply the changes in the PR
2. Compile and enter the realm.

### Known issues and TODO list
<!-- Is there anything else left to do after this PR? -->


---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
