### PR TITLE
(Sql/Creature Text) BroadcastTextId missing

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1661144462309668400.sql
+++ b/data/sql/updates/pending_db_world/rev_1661144462309668400.sql
@@ -1,0 +1,4 @@
+UPDATE `creature_text` SET `BroadcastTextId`=36124 WHERE `CreatureID`=34850 AND `GroupID`=0 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36125 WHERE `CreatureID`=34850 AND `GroupID`=1 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=36126 WHERE `CreatureID`=34850 AND `GroupID`=2 AND `ID`=0;
+UPDATE `creature_text` SET `BroadcastTextId`=39313 WHERE `CreatureID`=34851 AND `GroupID`=0 AND `ID`=0;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
### Changes proposed

- Link 4 BroadcastTextId of the worgen starting zone

### Issues addressed
<!-- If your fix has a relating issue, link it below -->

- Closes

### SOURCE:
<!-- If you can, include a source that can strengthen your claim -->


### Tests performed
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- Windows 10
- In-game

### How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Creates a worgen, enters the incido zone.
2. These are the texts that the king's son says.
3. After applying the change, if there is a translation, it should be displayed in several languages.

### Known issues and TODO list
<!-- Is there anything else left to do after this PR? -->


---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
