### PR TITLE
(Core/WorldSocket) Fixing the section closure

### DIFF
--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -701,11 +701,6 @@ void WorldSession::LogoutPlayer(bool save) {
     CharacterDatabase.Execute(stmt);
   }
 
-  if (m_Socket) {
-    m_Socket->CloseSocket();
-    m_Socket.reset();
-  }
-
   m_playerLogout = false;
   m_playerSave = false;
   m_playerRecentlyLogout = true;


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
### Changes proposed

- When you close the section, a message appears saying "you have been disconnected from the game", and you should return to character selection.

![WoWScrnShot_082222_212613](https://user-images.githubusercontent.com/2810187/186042427-6cace536-2d10-4286-9b80-239ba33e2dbc.jpg)

### Issues addressed
<!-- If your fix has a relating issue, link it below -->

- Closes

### SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

- Comparing the closure in other emulators.

### Tests performed
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- Windows 10
- In-game

### How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Enter the world with a character
2. Press the esc key, then disconnect from the game.
3. Before applying the game, an error message will appear, and you will automatically go to login again, when in fact, you should stay in the character selection.

### Known issues and TODO list
<!-- Is there anything else left to do after this PR? -->


---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
