### PR TITLE
(DB/Smart Scripts) Captive Worgen On Reset Morph To Model 30295

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1661234103799973200.sql
+++ b/data/sql/updates/pending_db_world/rev_1661234103799973200.sql
@@ -1,0 +1,8 @@
+UPDATE `creature_template` SET `AIName`='SmartAI', `ScriptName`='' WHERE `entry` IN (36698, 36797, 36798);
+
+DELETE FROM `smart_scripts` WHERE `entryorguid` IN (36698, 36797, 36798) AND `source_type`=0;
+
+INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
+(36698, 0, 0, 0, 25, 0, 100, 512, 0, 0, 0, 0, 0, 3, 36698, 30295, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Captive Worgen - On Reset - Morph To Model 30295"),
+(36797, 0, 0, 0, 25, 0, 100, 512, 0, 0, 0, 0, 0, 3, 36797, 30295, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Captive Worgen - On Reset - Morph To Model 30295"),
+(36798, 0, 0, 0, 25, 0, 100, 512, 0, 0, 0, 0, 0, 3, 36798, 30295, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Captive Worgen - On Reset - Morph To Model 30295");


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
### Changes proposed

- When we reach the second worgen zone, and after being released by the king, we see that there are some worgen prisoners, which are not always in their animal form.
- This is because, within creature_template, there are 4 different models for such NPCs. So with the following script, the intention is to force to always use one of them, and in this way, to emulate the retail content.

### Issues addressed
<!-- If your fix has a relating issue, link it below -->

- Closes

### SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

- World of Warcraft Retail

### Tests performed
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- Windows 10
- In-game

### How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Create a Worgen class character, do the first missions, until you are captured. After being released, you will see that sometimes some of the npc (as shown in the image) do not have the correct model, so it does not appear as captured. However, they do have the corresponding aura, but it must be accompanied by the model.
2. After testing this, run the script, close the server and run it again, logging back into the game. Now you will see that the captured worgen are correctly in their positions and in their animal form.
3. Check the attached images to corroborate the behavior before and after executing the script.

### Known issues and TODO list
<!-- Is there anything else left to do after this PR? -->


### Screenshots

Before

![WoWScrnShot_082322_031612](https://user-images.githubusercontent.com/2810187/186086428-4577affc-9bcd-4e0c-9b79-559e09c3df4a.jpg)

After

![WoWScrnShot_082322_031829](https://user-images.githubusercontent.com/2810187/186086457-82232849-d07f-4295-a979-71f36fe3d9e1.jpg)
---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
