### PR TITLE
(DB/Smart Scripts) Correct message in DBErrors

### DIFF
--- a/data/sql/updates/db_world/2022_08_23_00.sql
+++ b/data/sql/updates/db_world/2022_08_23_00.sql
@@ -3,6 +3,6 @@ UPDATE `creature_template` SET `AIName`='SmartAI', `ScriptName`='' WHERE `entry`
 DELETE FROM `smart_scripts` WHERE `entryorguid` IN (36698, 36797, 36798) AND `source_type`=0;
 
 INSERT INTO `smart_scripts` (`entryorguid`, `source_type`, `id`, `link`, `event_type`, `event_phase_mask`, `event_chance`, `event_flags`, `event_param1`, `event_param2`, `event_param3`, `event_param4`, `event_param5`, `action_type`, `action_param1`, `action_param2`, `action_param3`, `action_param4`, `action_param5`, `action_param6`, `target_type`, `target_param1`, `target_param2`, `target_param3`, `target_x`, `target_y`, `target_z`, `target_o`, `comment`) VALUES
-(36698, 0, 0, 0, 25, 0, 100, 512, 0, 0, 0, 0, 0, 3, 36698, 30295, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Captive Worgen - On Reset - Morph To Model 30295"),
-(36797, 0, 0, 0, 25, 0, 100, 512, 0, 0, 0, 0, 0, 3, 36797, 30295, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Captive Worgen - On Reset - Morph To Model 30295"),
-(36798, 0, 0, 0, 25, 0, 100, 512, 0, 0, 0, 0, 0, 3, 36798, 30295, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Captive Worgen - On Reset - Morph To Model 30295");
+(36698, 0, 0, 0, 25, 0, 100, 512, 0, 0, 0, 0, 0, 3, 0, 30295, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Captive Worgen - On Reset - Morph To Model 30295"),
+(36797, 0, 0, 0, 25, 0, 100, 512, 0, 0, 0, 0, 0, 3, 0, 30295, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Captive Worgen - On Reset - Morph To Model 30295"),
+(36798, 0, 0, 0, 25, 0, 100, 512, 0, 0, 0, 0, 0, 3, 0, 30295, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, "Captive Worgen - On Reset - Morph To Model 30295");


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
### Changes proposed

- Correct the message in the DBErrors file.
- From what I was researching, when using `action_type` 3, we should not opt for parameter 1 or 2, we cannot use both simultaneously. If we want the model to be random, we use the `action_param1`. If on the contrary, we want it to use a concrete model, we use the `action_param2` as in this case.

```
SmartAIMgr: Entry 36698 SourceType 0 Event 0 Action 3 has ModelID set with also set CreatureId, skipped.
SmartAIMgr: Entry 36797 SourceType 0 Event 0 Action 3 has ModelID set with also set CreatureId, skipped.
SmartAIMgr: Entry 36798 SourceType 0 Event 0 Action 3 has ModelID set with also set CreatureId, skipped.
```

### Issues addressed
<!-- If your fix has a relating issue, link it below -->

- Closes

### SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

- Examples of other `smart_scripts` with the same `action_type`.

### Tests performed
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- Windows 10
- In-game

### How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Before applying the change, check the DBErrors file.
2. When you do so, you will find the above message at the top.
3. Apply the change, and check inside the game, and then, if it works, in the DBErrors file.

### Known issues and TODO list
<!-- Is there anything else left to do after this PR? -->


---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
