### PR TITLE
Implement NPC Reload Command

### DIFF
--- a/data/sql/updates/pending_db_auth/rev_1661693714823101367.sql
+++ b/data/sql/updates/pending_db_auth/rev_1661693714823101367.sql
@@ -1,0 +1,5 @@
+--
+--
+DELETE FROM rbac_permissions WHERE id = 874;
+INSERT INTO rbac_permissions (id, name) VALUES
+(874, 'Command: npc reload');

--- a/data/sql/updates/pending_db_auth/rev_1661693714823101367.sql
+++ b/data/sql/updates/pending_db_auth/rev_1661693714823101367.sql
@@ -1,5 +1,3 @@
---
---
 DELETE FROM rbac_permissions WHERE id = 874;
 INSERT INTO rbac_permissions (id, name) VALUES
 (874, 'Command: npc reload');

--- a/data/sql/updates/pending_db_world/rev_1661693413752138084.sql
+++ b/data/sql/updates/pending_db_world/rev_1661693413752138084.sql
@@ -1,0 +1,6 @@
+--
+--
+DELETE FROM firelands_string WHERE entry IN (11020, 11021);
+INSERT INTO firelands_string (entry, content_default) VALUES
+(11020, 'Selected creature reloaded.'),
+(11021, 'Selected creature and all same entries in vision range reloaded.');

--- a/data/sql/updates/pending_db_world/rev_1661693413752138084.sql
+++ b/data/sql/updates/pending_db_world/rev_1661693413752138084.sql
@@ -1,5 +1,3 @@
---
---
 DELETE FROM firelands_string WHERE entry IN (11020, 11021);
 INSERT INTO firelands_string (entry, content_default) VALUES
 (11020, 'Selected creature reloaded.'),

--- a/src/server/game/AI/SmartScripts/SmartScript.cpp
+++ b/src/server/game/AI/SmartScripts/SmartScript.cpp
@@ -2817,8 +2817,7 @@ void SmartScript::GetTargets(ObjectVector& targets, SmartScriptHolder const& e, 
 
             if (!ref)
             {
-                LOG_ERROR("scripts.ai.sai", "SMART_TARGET_CLOSEST_CREATURE: Entry %u SourceType %s Event %u Action %u Target %u is missing base object or invoker.",
-                    e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType(), e.GetTargetType());
+                LOG_ERROR("scripts.ai.sai", "SMART_TARGET_CLOSEST_CREATURE: Entry %i SourceType %u Event %u Action %u Target %u is missing base object or invoker.", e.entryOrGuid, e.GetScriptType(), e.event_id, e.GetActionType(), e.GetTargetType());
                 break;
             }
 

--- a/src/server/game/Accounts/RBAC.h
+++ b/src/server/game/Accounts/RBAC.h
@@ -764,6 +764,7 @@ enum RBACPermissions
     RBAC_PERM_COMMAND_DEBUG_INSTANCESPAWN                    = 871,
     RBAC_PERM_COMMAND_SERVER_DEBUG                           = 872,
     RBAC_PERM_COMMAND_RELOAD_CREATURE_MOVEMENT_OVERRIDE      = 873,
+    RBAC_PERM_COMMAND_NPC_RELOAD                             = 874,
     //
     // IF YOU ADD NEW PERMISSIONS, ADD THEM IN MASTER BRANCH AS WELL!
     //

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3385,3 +3385,162 @@ void Creature::MakeInterruptable(bool apply)
     ApplySpellImmune(0, IMMUNITY_MECHANIC, MECHANIC_INTERRUPT, !apply);
     ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_INTERRUPT_CAST, !apply);
 }
+
+/**
+ * It reloads the creature's data from the database
+ *
+ * @param skipDatabase If true, the creature will not be reloaded from the database.
+ *
+ * @return The creature's entry.
+ */
+void Creature::Reload(bool skipDatabase)
+{
+    uint32 entry = GetEntry();
+
+    InterruptNonMeleeSpells(false);
+    RemoveAllAuras();
+
+    PreparedQueryResult result;
+    if (!skipDatabase)
+    {
+        WorldDatabasePreparedStatement* stmt = WorldDatabase.GetPreparedStatement(WORLD_SEL_CREATURE_TEMPLATE);
+        stmt->setUInt32(0, entry);
+        result = WorldDatabase.Query(stmt);
+
+        if (!result)
+        {
+            LOG_ERROR("sql.sql", "Creature template %u not found for reload...", GetEntry());
+            return;
+        }
+
+        Field* fields = result->Fetch();
+        sObjectMgr->LoadCreatureTemplate(fields);
+        sObjectMgr->LoadCreatureModelInfo();
+        sObjectMgr->LoadCreatureAddons();
+        sObjectMgr->LoadCreatureTemplateAddons();
+        sObjectMgr->LoadCreatureMovementInfo();
+        sObjectMgr->LoadCreatureMovementOverrides();
+    }
+
+    CreatureTemplate const* cInfo = sObjectMgr->GetCreatureTemplate(entry);
+    if (!cInfo)
+    {
+        LOG_ERROR("sql.sql", "Creature template info %u not found for reload...", GetEntry());
+        return;
+    }
+
+    CreatureData const* data = sObjectMgr->GetCreatureData(GetSpawnId());
+    if (!data)
+    {
+        LOG_ERROR("sql.sql", "Creature SpawnID (" SI64FMTD ") does not exist, skipped re-loading.", GetSpawnId());
+        return;
+    }
+
+    if (!skipDatabase)
+    {
+        sObjectMgr->CheckCreatureTemplate(cInfo);
+
+        QueryResult scriptQuery = WorldDatabase.PQuery("SELECT ScriptName FROM creature WHERE guid = %u", GetSpawnId());
+        if (!scriptQuery)
+        {
+            LOG_ERROR("sql.sql", "Creature SpawnID (" SI64FMTD ") not found in creature table, skipped re-loading.", GetSpawnId());
+            return;
+        }
+
+        Field* fields = scriptQuery->Fetch();
+        CreatureData& cdata = sObjectMgr->NewOrExistCreatureData(GetSpawnId());
+        cdata.scriptId = sObjectMgr->GetScriptId(fields[0].GetString());
+
+        if (!cdata.scriptId)
+        {
+            cdata.scriptId = cInfo->ScriptID;
+        }
+    }
+
+    Relocate(data->spawnPoint.GetPositionX(), data->spawnPoint.GetPositionY(), data->spawnPoint.GetPositionZ(), data->spawnPoint.GetOrientation());
+
+    // Check if the position is valid before calling from CreateFromProto(), otherwise we might add Auras to Creatures at invalid position
+    // and triggering a crash about Auras not removed in the destructor
+    if (!IsPositionValid())
+    {
+        LOG_ERROR("entities.unit", "Creature::Create(): given coordinates for creature (SpawnID " UI64FMTD ", entry %d) are not valid (X: %f, Y: %f, Z: %f, O: %f)",
+            GetSpawnId(), GetEntry(), data->spawnPoint.GetPositionX(), data->spawnPoint.GetPositionY(), data->spawnPoint.GetPositionZ(), data->spawnPoint.GetOrientation());
+        return;
+    }   
+
+    if (!CreateFromProto(GetGUID().GetCounter(), entry, data, cInfo->VehicleId))
+        return;
+
+    switch (GetCreatureTemplate()->rank)
+    {
+	    case CREATURE_ELITE_RARE:
+		    m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_RARE);
+		    break;
+
+	    case CREATURE_ELITE_ELITE:
+		    m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_ELITE);
+		    break;
+
+	    case CREATURE_ELITE_RAREELITE:
+		    m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_RAREELITE);
+		    break;
+
+	    case CREATURE_ELITE_WORLDBOSS:
+		    m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_WORLDBOSS);
+		    break;
+
+	    default:
+		    m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_NORMAL);
+		    break;
+    }
+
+    LoadCreaturesAddon();
+
+    // Need to be called before LoadCreatureAddon - MOVEMENTFLAG_HOVER is set there
+    if (HasUnitMovementFlag(MOVEMENTFLAG_HOVER))
+    {
+        float z = data->spawnPoint.GetPositionZ() + GetFloatValue(UNIT_FIELD_HOVERHEIGHT);
+
+        // Relocate again with updated Z coord
+        Relocate(data->spawnPoint.GetPositionX(), data->spawnPoint.GetPositionY(), z, data->spawnPoint.GetOrientation());
+    }
+
+    uint32 displayId = GetNativeDisplayId();
+    CreatureModelInfo const* mInfo = sObjectMgr->GetCreatureModelRandomGender(&displayId);
+    if (mInfo && !IsTotem())
+    {
+        SetDisplayId(displayId);
+        SetNativeDisplayId(displayId);
+        SetByteValue(UNIT_FIELD_BYTES_0, UNIT_BYTES_0_OFFSET_GENDER, mInfo->gender);
+    }
+
+    LastUsedScriptID = GetScriptId();
+
+    if (IsSpiritHealer() || IsSpiritGuide())
+    {
+        m_serverSideVisibility.SetValue(SERVERSIDE_VISIBILITY_GHOST, GHOST_VISIBILITY_GHOST);
+        m_serverSideVisibilityDetect.SetValue(SERVERSIDE_VISIBILITY_GHOST, GHOST_VISIBILITY_GHOST);
+    }
+
+    if (GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_IGNORE_PATHFINDING)
+    {
+        AddUnitState(UNIT_STATE_IGNORE_PATHFINDING);
+    }
+
+    if (GetCreatureTemplate()->flags_extra & CREATURE_FLAG_EXTRA_IMMUNITY_KNOCKBACK)
+    {
+        ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_KNOCK_BACK, true);
+        ApplySpellImmune(0, IMMUNITY_EFFECT, SPELL_EFFECT_KNOCK_BACK_DEST, true);
+    }
+
+    AIM_Initialize();
+
+    Respawn();
+
+    if (IsAIEnabled())
+    {
+        AI()->EnterEvadeMode();
+    }
+
+    LOG_DEBUG("sql.sql", "Creature SpawnId (" SI64FMTD ") reloaded.", GetSpawnId());
+}

--- a/src/server/game/Entities/Creature/Creature.cpp
+++ b/src/server/game/Entities/Creature/Creature.cpp
@@ -3466,32 +3466,32 @@ void Creature::Reload(bool skipDatabase)
         LOG_ERROR("entities.unit", "Creature::Create(): given coordinates for creature (SpawnID " UI64FMTD ", entry %d) are not valid (X: %f, Y: %f, Z: %f, O: %f)",
             GetSpawnId(), GetEntry(), data->spawnPoint.GetPositionX(), data->spawnPoint.GetPositionY(), data->spawnPoint.GetPositionZ(), data->spawnPoint.GetOrientation());
         return;
-    }   
+    }
 
     if (!CreateFromProto(GetGUID().GetCounter(), entry, data, cInfo->VehicleId))
         return;
 
     switch (GetCreatureTemplate()->rank)
     {
-	    case CREATURE_ELITE_RARE:
-		    m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_RARE);
-		    break;
+        case CREATURE_ELITE_RARE:
+            m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_RARE);
+            break;
 
-	    case CREATURE_ELITE_ELITE:
-		    m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_ELITE);
-		    break;
+        case CREATURE_ELITE_ELITE:
+            m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_ELITE);
+            break;
 
-	    case CREATURE_ELITE_RAREELITE:
-		    m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_RAREELITE);
-		    break;
+        case CREATURE_ELITE_RAREELITE:
+            m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_RAREELITE);
+            break;
 
-	    case CREATURE_ELITE_WORLDBOSS:
-		    m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_WORLDBOSS);
-		    break;
+        case CREATURE_ELITE_WORLDBOSS:
+            m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_WORLDBOSS);
+            break;
 
-	    default:
-		    m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_NORMAL);
-		    break;
+        default:
+            m_corpseDelay = sWorld->getIntConfig(CONFIG_CORPSE_DECAY_NORMAL);
+            break;
     }
 
     LoadCreaturesAddon();

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -79,6 +79,7 @@ class FC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         void UpdateLevelDependantStats();
         void LoadEquipment(int8 id = 1, bool force = false);
         void SetSpawnHealth();
+        void Reload(bool skipDatabase);
 
         ObjectGuid::LowType GetSpawnId() const { return m_spawnId; }
 

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -565,6 +565,8 @@ void ObjectMgr::LoadCreatureTemplateAddons()
 {
     uint32 oldMSTime = getMSTime();
 
+    _creatureTemplateAddonStore.clear(); // needed for reload
+
     //                                                 0    1               2                   3      4       5       6      7          8                9             10                      11
     QueryResult result = WorldDatabase.Query("SELECT entry, waypointPathId, cyclicSplinePathId, mount, bytes1, bytes2, emote, aiAnimKit, movementAnimKit, meleeAnimKit, visibilityDistanceType, auras FROM creature_template_addon");
 
@@ -1148,6 +1150,8 @@ void ObjectMgr::CheckCreatureMovement(char const* table, uint64 id, CreatureMove
 void ObjectMgr::LoadCreatureAddons()
 {
     uint32 oldMSTime = getMSTime();
+
+    _creatureAddonStore.clear(); // needed for reload
 
     //                                               0     1               2                   3      4       5       6      7          8                9             10                      11
     QueryResult result = WorldDatabase.Query("SELECT guid, waypointPathId, cyclicSplinePathId, mount, bytes1, bytes2, emote, aiAnimKit, movementAnimKit, meleeAnimKit, visibilityDistanceType, auras FROM creature_addon");

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -1155,6 +1155,10 @@ enum FirelandsStrings
     LANG_CREATURE_NOT_AI_ENABLED                  = 11015,
     LANG_SELECT_PLAYER_OR_PET                     = 11016,
     LANG_SHUTDOWN_DELAYED                         = 11017,
-    LANG_SHUTDOWN_CANCELLED                       = 11018
+    LANG_SHUTDOWN_CANCELLED                       = 11018,
+
+    // For NPC reload command
+    LANG_NPC_RELOADED                             = 11020,
+    LANG_NPCS_RELOADED                            = 11021,
 };
 #endif

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -325,6 +325,7 @@ public:
             { "set",          rbac::RBAC_PERM_COMMAND_NPC_SET,          false, nullptr,              "", npcSetCommandTable },
             { "evade",        rbac::RBAC_PERM_COMMAND_NPC_EVADE,        false, &HandleNpcEvadeCommand,             ""       },
             { "showloot",     rbac::RBAC_PERM_COMMAND_NPC_SHOWLOOT,     false, &HandleNpcShowLootCommand,          ""       },
+            { "reload",       rbac::RBAC_PERM_COMMAND_NPC_RELOAD,       false, &HandleNpcReloadCommand,            ""       },
         };
         static std::vector<ChatCommand> commandTable =
         {
@@ -1823,6 +1824,43 @@ public:
             return true;
         }
         */
+        return true;
+    }
+
+    static bool HandleNpcReloadCommand(ChatHandler* handler, char const* args)
+    {
+        Creature* creatureTarget = handler->getSelectedCreature();
+        if (!creatureTarget || creatureTarget->IsPet() || creatureTarget->IsGuardian())
+        {
+            handler->PSendSysMessage(LANG_SELECT_CREATURE);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
+
+        creatureTarget->Reload(false);
+
+        if (args && stricmp(args, "all") == 0)
+        {
+            Player* player = handler->GetSession()->GetPlayer();
+            std::list<Creature*> list;
+
+            player->GetCreatureListWithEntryInGrid(list, creatureTarget->GetEntry(), player->GetMap()->GetVisibilityRange());
+
+            for (Creature* creature : list)
+            {
+                if (creature != creatureTarget)
+                {
+                    creature->Reload(true);
+                }
+            }
+
+            handler->PSendSysMessage(LANG_NPCS_RELOADED);
+        }
+        else
+        {
+            handler->PSendSysMessage(LANG_NPC_RELOADED);
+        }
+
         return true;
     }
 };


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
### Changes proposed

- Add the ability to reload creature data without restarting the server. All changes are global on that creature depending on type of reload done. Players will be able to use that creature after the reload is finished. 

### Tests performed
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- Builds and Runs without issues
- Tests where done on Debian 11

### How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. See video link below

**What does this command reload?**
```
- Reloads creature template data for the selected creature, not data from other entries
- Reloads creature model data
- Reloads creature addons
- Reloads creature template addons
- Reloads creature movement information
- Reloads creature movement overrides
```

**Notice:** If using query cache, command will take a second or two too reload the cache stored in memory. Sometimes the NPCs will disappear for a few seconds and reappear. This is normal.

https://cdn.discordapp.com/attachments/1001270108838174880/1013456146461372416/creature_reloading.webm

---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
