### PR TITLE
Fix Warsong Gluch Capture Points

### DIFF
--- a/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
+++ b/src/server/game/Battlegrounds/Zones/BattlegroundWS.cpp
@@ -516,6 +516,14 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
             PlaySoundToAll(BG_WS_SOUND_FLAG_RETURNED);
             UpdatePlayerScore(player, SCORE_FLAG_RETURNS, 1);
             _bothFlagsKept = false;
+
+            if (Player* hordeFlagCarrier = ObjectAccessor::GetPlayer(GetBgMap(), GetFlagPickerGUID(TEAM_HORDE)))
+            {
+                if (hordeFlagCarrier->IsInAreaTriggerRadius(sAreaTriggerStore.LookupEntry(3646)))
+                {
+                    EventPlayerCapturedFlag(hordeFlagCarrier);
+                }
+            }
         }
         else
         {
@@ -549,6 +557,14 @@ void BattlegroundWS::EventPlayerClickedOnFlag(Player* player, GameObject* target
             PlaySoundToAll(BG_WS_SOUND_FLAG_RETURNED);
             UpdatePlayerScore(player, SCORE_FLAG_RETURNS, 1);
             _bothFlagsKept = false;
+
+            if (Player* allianceFlagCarrier = ObjectAccessor::GetPlayer(GetBgMap(), GetFlagPickerGUID(TEAM_ALLIANCE)))
+            {
+                if (allianceFlagCarrier->IsInAreaTriggerRadius(sAreaTriggerStore.LookupEntry(3647)))
+                {
+                    EventPlayerCapturedFlag(allianceFlagCarrier);
+                }
+            }
         }
         else
         {


### PR DESCRIPTION
Co-authored-by: CoderKane <CoderKane@users.noreply.github.com>

<!-- First of all, THANK YOU for your contribution. -->
### Changes proposed

- Fix capture points for team flags.

### Steps to reproduce the problem before PR
- Pick up Flag on both sides
- Get on the Capture Point with one of the Flags
- Return the other flag
- Now you'll see the Flag doesn't Capture, until you've walked off and onto the Capture Point.

### Tests performed
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- Builds without issues
- Tested in-game and works from what I can tell when testing with a few friends.

### How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Repeat the steps above after patching, without walking off the capture point.

---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
