### PR TITLE
fix (core): change order in HandleLootOpcode

### DIFF
--- a/src/server/game/Handlers/LootHandler.cpp
+++ b/src/server/game/Handlers/LootHandler.cpp
@@ -282,12 +282,11 @@ void WorldSession::HandleLootOpcode(WorldPacket& recvData)
     if (!GetPlayer()->IsAlive() || !guid.IsCreatureOrVehicle())
         return;
 
-    GetPlayer()->SendLoot(guid, LOOT_CORPSE);
-
     // interrupt cast
     if (GetPlayer()->IsNonMeleeSpellCast(false))
         GetPlayer()->InterruptNonMeleeSpells(false);
 
+    GetPlayer()->SendLoot(guid, LOOT_CORPSE);
     GetPlayer()->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags::Looting);
 }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->


I just can not understand why we have a check occuring after SendLoot. All checks should be before it in this case. Viewing gitblame, this was last touched back about 13 years ago and with no notes explaining the reasoning. Would love a further explaination in the reason why interrupt cast if statement is occurring after a send loot and not before.

### Changes proposed

- Change Order of GetPlayer()->SendLoot(guid, LOOT_CORPSE); to occur after checks and not inbetween checks within the HandleLootOpcode.


### Issues addressed
<!-- If your fix has a relating issue, link it below -->

- Closes

### SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

- conditional if checks should be executed before the related action.

### Tests performed
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

-  It does build with no issues in game from what i can see.

### How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. I am able to craft multiple items with tayloring, and able to loot corpses just fine.
cast spells or while crafting does get interrupted when i decide to loot something

### Known issues and TODO list
<!-- Is there anything else left to do after this PR? -->

- [ ] 
- [ ] 

---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
