### PR TITLE
Fix (core): Flight Paths on Faction Changes

### DIFF
--- a/src/server/game/DataStores/DBCStores.cpp
+++ b/src/server/game/DataStores/DBCStores.cpp
@@ -21,6 +21,7 @@
 #include "DBCfmt.h"
 #include "Errors.h"
 #include "ItemTemplate.h"
+#include "LFGMgr.h"
 #include "Log.h"
 #include "ObjectDefines.h"
 #include "Player.h"
@@ -707,7 +708,7 @@ void DBCManager::LoadStores(const std::string& dataPath, uint32 defaultLocale)
         sTalentTreePrimarySpellsMap[talentSpell->TalentTabID].push_back(talentSpell->SpellID);
 
     for (TaxiPathEntry const* entry : sTaxiPathStore)
-        sTaxiPathSetBySource[entry->FromTaxiNode][entry->ToTaxiNode] = TaxiPathBySourceAndDestination(entry->ID, entry->Cost);
+        sTaxiPathSetBySource[entry->FromTaxiNode][entry->ToTaxiNode] = entry;
 
     uint32 pathCount = sTaxiPathStore.GetNumRows();
     // Calculate path nodes count
@@ -750,7 +751,7 @@ void DBCManager::LoadStores(const std::string& dataPath, uint32 defaultLocale)
                 for (TaxiPathSetForSource::const_iterator dest_i = src_i->second.begin(); dest_i != src_i->second.end(); ++dest_i)
                 {
                     // not spell path
-                    if (dest_i->second.price || spellPaths.find(dest_i->second.ID) == spellPaths.end())
+                    if (dest_i->second->Cost || spellPaths.find(dest_i->second->ID) == spellPaths.end())
                     {
                         ok = true;
                         break;
@@ -1256,6 +1257,19 @@ LFGDungeonEntry const* DBCManager::GetLFGDungeon(uint32 mapId, Difficulty diffic
 
         if (dungeon->MapID == int32(mapId) && Difficulty(dungeon->DifficultyID) == difficulty)
             return dungeon;
+    }
+
+    return nullptr;
+}
+
+LFGDungeonEntry const* DBCManager::GetLFGZoneEntry(const std::string& zoneName, LocaleConstant locale)
+{
+    for (LFGDungeonEntry const* dungeon : sLFGDungeonStore)
+    {
+        if (dungeon->TypeID == lfg::LFG_TYPE_ZONE && zoneName.find(dungeon->Name[locale]) != std::string::npos)
+        {
+            return dungeon;
+        }
     }
 
     return nullptr;

--- a/src/server/game/DataStores/DBCStores.h
+++ b/src/server/game/DataStores/DBCStores.h
@@ -244,6 +244,7 @@ public:
     uint32 GetPowerIndexByClass(Powers power, uint32 classId);
     static bool IsInArea(uint32 objectAreaId, uint32 areaId);
     static LFGDungeonEntry const* GetLFGDungeon(uint32 mapId, Difficulty difficulty);
+    static LFGDungeonEntry const* GetLFGZoneEntry(const std::string& zoneName, LocaleConstant locale);
     std::vector<uint32> const* GetPhasesForGroup(uint32 group);
     std::vector<SkillLineAbilityEntry const*> const* GetSkillLineAbilitiesBySkill(uint32 skillId) const;
     SkillRaceClassInfoEntry const* GetSkillRaceClassInfo(uint32 skill, uint8 race, uint8 class_);

--- a/src/server/game/DataStores/DBCStructure.h
+++ b/src/server/game/DataStores/DBCStructure.h
@@ -2354,15 +2354,7 @@ struct TalentSpellPos
 
 typedef std::map<uint32, TalentSpellPos> TalentSpellPosMap;
 
-struct TaxiPathBySourceAndDestination
-{
-    TaxiPathBySourceAndDestination() : ID(0), price(0) { }
-    TaxiPathBySourceAndDestination(uint32 _id, uint32 _price) : ID(_id), price(_price) { }
-
-    uint32    ID;
-    uint32    price;
-};
-typedef std::map<uint32, TaxiPathBySourceAndDestination> TaxiPathSetForSource;
+typedef std::map<uint32, TaxiPathEntry const*> TaxiPathSetForSource;
 typedef std::map<uint32, TaxiPathSetForSource> TaxiPathSetBySource;
 
 typedef std::vector<TaxiPathNodeEntry const*> TaxiPathNodeList;

--- a/src/server/game/DungeonFinding/LFGMgr.h
+++ b/src/server/game/DungeonFinding/LFGMgr.h
@@ -78,6 +78,7 @@ enum LfgType
     LFG_TYPE_NONE                                = 0,
     LFG_TYPE_DUNGEON                             = 1,
     LFG_TYPE_RAID                                = 2,
+    LFG_TYPE_ZONE                                = 4,
     LFG_TYPE_HEROIC                              = 5,
     LFG_TYPE_RANDOM                              = 6
 };

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -6442,8 +6442,8 @@ void ObjectMgr::GetTaxiPath(uint32 source, uint32 destination, uint32 &path, uin
         return;
     }
 
-    cost = dest_i->second.price;
-    path = dest_i->second.ID;
+    cost = dest_i->second->Cost;
+    path = dest_i->second->ID;
 }
 
 uint32 ObjectMgr::GetTaxiMountDisplayId(uint32 id, uint32 team, bool allowed_alt_team /* = false */)

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -24,6 +24,7 @@
 #include "CharacterCache.h"
 #include "CharacterPackets.h"
 #include "Chat.h"
+#include "DB2Stores.h"
 #include "DBCStores.h"
 #include "DatabaseEnv.h"
 #include "GameObject.h"
@@ -39,12 +40,14 @@
 #include "Language.h"
 #include "Log.h"
 #include "Map.h"
+#include "MapManager.h"
 #include "Metric.h"
 #include "MotionMaster.h"
 #include "ObjectAccessor.h"
 #include "ObjectMgr.h"
 #include "Opcodes.h"
 #include "Pet.h"
+#include "PhasingHandler.h"
 #include "Player.h"
 #include "PlayerDump.h"
 #include "QueryHolder.h"
@@ -2029,32 +2032,95 @@ void WorldSession::HandleCharFactionOrRaceChangeCallback(std::shared_ptr<Charact
 
         if (factionChangeInfo->FactionChange)
         {
-            // Delete all Flypaths
-            stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_CHAR_TAXI_PATH);
-            stmt->setUInt32(0, lowGuid);
-            trans->Append(stmt);
-
-            if (level > 7)
             {
+                // Delete all Flypaths
+                stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_CHAR_TAXI_PATH);
+                stmt->setUInt32(0, lowGuid);
+                trans->Append(stmt);
                 // Update Taxi path
-                // this doesn't seem to be 100% blizzlike... but it can't really be
-                // helped.
-                std::ostringstream taximaskstream;
-                uint32 numFullTaximasks = level / 7;
-                if (numFullTaximasks > 11)
-                    numFullTaximasks = 11;
+                TaxiMask SwitchedTaxiMask;
+                memset(&SwitchedTaxiMask, 0, sizeof(SwitchedTaxiMask));
 
                 TaxiMask const& factionMask = newTeam == HORDE ? sHordeTaxiNodesMask : sAllianceTaxiNodesMask;
-                for (uint8 i = 0; i < numFullTaximasks; ++i)
+                for (auto const& itr : sTaxiPathSetBySource)
                 {
-                    uint8 deathKnightExtraNode = (playerClass == CLASS_DEATH_KNIGHT) ? sDeathKnightTaxiNodesMask[i] : 0;
-                    taximaskstream << uint32(factionMask[i] | deathKnightExtraNode) << ' ';
+                    auto TaxiMaskBuild = [&](uint8 field, uint32 mask)
+                    {
+                        if (playerClass == CLASS_DEATH_KNIGHT)
+                        {
+                            SwitchedTaxiMask[field] |= uint32(mask | (sDeathKnightTaxiNodesMask[field] & mask));
+                        }
+                        else
+                        {
+                            SwitchedTaxiMask[field] |= mask;
+                        }
+                    };
+
+                    uint32 nodeId = itr.first;
+                    uint8 field = (uint8)((nodeId - 1) / 32);
+                    uint32 submask = 1 << ((nodeId - 1) % 32);
+
+                    if ((factionMask[field] & submask) == 0)
+                    {
+                        TaxiMaskBuild(field, 0);
+                        continue;
+                    }
+
+                    TaxiPathSetForSource const& taxiPaths = itr.second;
+                    if (taxiPaths.empty())
+                    {
+                        TaxiMaskBuild(field, 0);
+                        continue;
+                    }
+                    TaxiPathEntry const* taxiPath = taxiPaths.begin()->second;
+                    if (!taxiPath)
+                    {
+                        TaxiMaskBuild(field, 0);
+                        continue;
+                    }
+
+                    TaxiPathNodeList const& taxiNodePaths = sTaxiPathNodesByPath[taxiPath->ID];
+                    if (taxiNodePaths.empty())
+                    {
+                        TaxiMaskBuild(field, 0);
+                        continue;
+                    }
+
+                    TaxiPathNodeEntry const* pathNode = taxiNodePaths.front();
+                    if (!pathNode)
+                    {
+                        TaxiMaskBuild(field, 0);
+                        continue;
+                    }
+
+                    AreaTableEntry const* zone =
+                        sAreaTableStore.LookupEntry(sMapMgr->GetZoneId(PhasingHandler::GetEmptyPhaseShift(), pathNode->ContinentID, pathNode->Loc.X, pathNode->Loc.Y, pathNode->Loc.Z));
+                    if (!zone)
+                    {
+                        TaxiMaskBuild(field, 0);
+                        continue;
+                    }
+
+                    LFGDungeonEntry const* lfgZone = DBCManager::GetLFGZoneEntry(zone->AreaName, GetSessionDbLocaleIndex());
+                    if (!lfgZone)
+                    {
+                        TaxiMaskBuild(field, 0);
+                        continue;
+                    }
+
+                    // Get level from LFGDungeonEntry because the one from AreaTableEntry is not valid
+                    if (lfgZone->MinLevel > level)
+                    {
+                        TaxiMaskBuild(field, 0);
+                        continue;
+                    }
+
+                    TaxiMaskBuild(field, submask);
                 }
 
-                uint32 numEmptyTaximasks = 11 - numFullTaximasks;
-                for (uint8 i = 0; i < numEmptyTaximasks; ++i)
-                    taximaskstream << "0 ";
-                taximaskstream << '0';
+                std::ostringstream taximaskstream;
+                for (uint8 i = 0; i < TaxiMaskSize; ++i)
+                    taximaskstream << uint32(SwitchedTaxiMask[i]) << ' ';
 
                 stmt = CharacterDatabase.GetPreparedStatement(CHAR_UPD_CHAR_TAXIMASK);
                 stmt->setString(0, taximaskstream.str());

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -2174,7 +2174,7 @@ void WorldSession::HandleCharFactionOrRaceChangeCallback(std::shared_ptr<Charact
             }
             else
             {
-                loc.WorldRelocate(1, 1633.33f, -4439.11f, 15.7588f, 0.0f);
+                loc.WorldRelocate(1, 1565.64f, -4400.45f, 16.3835f, 0.0f);
                 zoneId = 1637;
             }
 


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
### Changes proposed

- Level Appropiate Flight Points on Faction Change, currently all flight points open up for players for the factions they swap to regardless of level. We used the lfg system and create a LFG Zone to handle per level

### Issues addressed
<!-- If your fix has a relating issue, link it below -->

- Closes source notes in characterhandler.cpp 
![image](https://github.com/FirelandsProject/firelands-cata/assets/16887899/4659a74a-a9f9-481e-8fc8-0ac884c1f727)

### Tests performed
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

1. Builds and runs


### How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Perform a .character changefaction on any mid or low level character just so you dont see all points as if it was max character.
2. observe flight points that are unlocked via flight mangers
3. Fine tuned the horde coordinates on faction swap as the old location was clippinged the player under the auction house.

horde level 21
![image](https://github.com/FirelandsProject/firelands-cata/assets/16887899/372b7ffd-41e0-44aa-8362-37a906295a1d)

alliance level 21
![image](https://github.com/FirelandsProject/firelands-cata/assets/16887899/caca83ee-e41e-4fd8-801a-0089a590e89d)

### Known issues and TODO list
<!-- Is there anything else left to do after this PR? -->

- [ ] 
- [ ] 

---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
