### PR TITLE
Implement Item Disable

### DIFF
--- a/data/sql/updates/pending_db_auth/rev_1694010102868990400.sql
+++ b/data/sql/updates/pending_db_auth/rev_1694010102868990400.sql
@@ -1,0 +1,10 @@
+--
+DELETE FROM rbac_permissions WHERE id IN (875, 876);
+INSERT INTO rbac_permissions (id, name) VALUES
+(875, 'Command: disable add item'),
+(876, 'Command: disable remove item');
+
+DELETE FROM rbac_linked_permissions WHERE id = 196 AND linkedId IN (875, 876);
+INSERT INTO rbac_linked_permissions (id, linkedId) VALUES
+(196, 875),
+(196, 876);

--- a/data/sql/updates/pending_db_world/rev_1694010110716792900.sql
+++ b/data/sql/updates/pending_db_world/rev_1694010110716792900.sql
@@ -1,0 +1,5 @@
+--
+DELETE FROM command WHERE name IN ('disable add item', 'disable remove item');
+INSERT INTO command (name, permission, help) VALUES
+('disable add item', 875, 'Syntax: .disable add item #itemId #flag'),
+('disable remove item', 876, 'Syntax: .disable remove item #itemId');

--- a/data/sql/updates/pending_db_world/rev_1694010110716792900.sql
+++ b/data/sql/updates/pending_db_world/rev_1694010110716792900.sql
@@ -3,3 +3,11 @@ DELETE FROM command WHERE name IN ('disable add item', 'disable remove item');
 INSERT INTO command (name, permission, help) VALUES
 ('disable add item', 875, 'Syntax: .disable add item #itemId #flag'),
 ('disable remove item', 876, 'Syntax: .disable remove item #itemId');
+
+--
+DELETE FROM disables WHERE sourceType = 9;
+INSERT INTO disables (sourceType, entry, flags, comment) VALUES
+(9,  2586, 3, 'Disable item 2586 (GameMaster\'s Robe) for Auction House Player & Bot'),
+(9, 11508, 3, 'Disable item 11508 (GameMaster\'s Slippers) for Auction House Player & Bot'),
+(9, 12064, 3, 'Disable item 12064 (GameMaster\'s Hood) for Auction House Player & Bot'),
+(9,  7192, 2, 'Disable item 7192 (Plans: Goblin Rocket Boots) for Auction House Bot');

--- a/src/server/game/Accounts/RBAC.h
+++ b/src/server/game/Accounts/RBAC.h
@@ -765,6 +765,9 @@ enum RBACPermissions
     RBAC_PERM_COMMAND_SERVER_DEBUG                           = 872,
     RBAC_PERM_COMMAND_RELOAD_CREATURE_MOVEMENT_OVERRIDE      = 873,
     RBAC_PERM_COMMAND_NPC_RELOAD                             = 874,
+    RBAC_PERM_COMMAND_DISABLE_ADD_ITEM                       = 875,
+    RBAC_PERM_COMMAND_DISABLE_REMOVE_ITEM                    = 876,
+
     //
     // IF YOU ADD NEW PERMISSIONS, ADD THEM IN MASTER BRANCH AS WELL!
     //

--- a/src/server/game/AuctionHouse/AuctionHouseMgr.h
+++ b/src/server/game/AuctionHouse/AuctionHouseMgr.h
@@ -20,6 +20,7 @@
 
 #include "Define.h"
 #include "DatabaseEnvFwd.h"
+#include "DisableMgr.h"
 #include "ObjectGuid.h"
 #include <map>
 #include <set>

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -147,7 +147,6 @@ void AuctionBotConfig::GetConfigFromFile()
     SetConfigMax(CONFIG_AHBOT_NEUTRAL_ITEM_AMOUNT_RATIO, "AuctionHouseBot.Neutral.Items.Amount.Ratio", 100, 10000);
 
     SetAHBotIncludes(sConfigMgr->GetStringDefault("AuctionHouseBot.forceIncludeItems", ""));
-    SetAHBotExcludes(sConfigMgr->GetStringDefault("AuctionHouseBot.forceExcludeItems", ""));
 
     SetConfig(CONFIG_AHBOT_BUYER_ALLIANCE_ENABLED, "AuctionHouseBot.Buyer.Alliance.Enabled", false);
     SetConfig(CONFIG_AHBOT_BUYER_HORDE_ENABLED, "AuctionHouseBot.Buyer.Horde.Enabled", false);

--- a/src/server/game/AuctionHouseBot/AuctionHouseBot.h
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBot.h
@@ -215,7 +215,6 @@ public:
 
     bool Initialize();
     std::string const& GetAHBotIncludes() const { return _AHBotIncludes; }
-    std::string const& GetAHBotExcludes() const { return _AHBotExcludes; }
 
     uint32 GetConfig(AuctionBotConfigUInt32Values index) const { return _configUint32Values[index]; }
     bool GetConfig(AuctionBotConfigBoolValues index) const { return _configBoolValues[index]; }
@@ -240,7 +239,6 @@ public:
 
 private:
     std::string _AHBotIncludes;
-    std::string _AHBotExcludes;
     std::vector<uint32> _AHBotCharacters;
     uint32 _itemsPerCycleBoost;
     uint32 _itemsPerCycleNormal;
@@ -250,7 +248,6 @@ private:
     float _configFloatValues[CONFIG_AHBOT_FLOAT_COUNT];
 
     void SetAHBotIncludes(const std::string& AHBotIncludes) { _AHBotIncludes = AHBotIncludes; }
-    void SetAHBotExcludes(const std::string& AHBotExcludes) { _AHBotExcludes = AHBotExcludes; }
 
     void SetConfig(AuctionBotConfigUInt32Values index, char const* fieldname, uint32 defvalue);
     void SetConfigMax(AuctionBotConfigUInt32Values index, char const* fieldname, uint32 defvalue, uint32 maxvalue);

--- a/src/server/game/AuctionHouseBot/AuctionHouseBotSeller.cpp
+++ b/src/server/game/AuctionHouseBot/AuctionHouseBotSeller.cpp
@@ -44,7 +44,6 @@ bool AuctionBotSeller::Initialize()
     std::unordered_set<uint32> npcItems;
     std::unordered_set<uint32> lootItems;
     std::unordered_set<uint32> includeItems;
-    std::unordered_set<uint32> excludeItems;
 
     LOG_DEBUG("ahbot", "AHBot seller filters:");
 
@@ -55,15 +54,7 @@ bool AuctionBotSeller::Initialize()
             includeItems.insert(atoi(temp.c_str()));
     }
 
-    {
-        std::stringstream excludeStream(sAuctionBotConfig->GetAHBotExcludes());
-        std::string temp;
-        while (std::getline(excludeStream, temp, ','))
-            excludeItems.insert(atoi(temp.c_str()));
-    }
-
     LOG_DEBUG("ahbot", "Forced Inclusion %u items", (uint32)includeItems.size());
-    LOG_DEBUG("ahbot", "Forced Exclusion %u items", (uint32)excludeItems.size());
 
     LOG_DEBUG("ahbot", "Loading npc vendor items for filter..");
     CreatureTemplateContainer const* creatures = sObjectMgr->GetCreatureTemplates();
@@ -106,8 +97,7 @@ bool AuctionBotSeller::Initialize()
         if (prototype->GetQuality() >= MAX_AUCTION_QUALITY)
             continue;
 
-        // forced exclude filter
-        if (excludeItems.count(itemId))
+        if (DisableMgr::IsDisabledFor(DISABLE_TYPE_ITEM, itemId, nullptr, ITEM_DISABLE_AUCTIONHOUSE_BOT))
             continue;
 
         // forced include filter

--- a/src/server/game/Conditions/DisableMgr.cpp
+++ b/src/server/game/Conditions/DisableMgr.cpp
@@ -44,7 +44,7 @@ namespace
 
     DisableMap m_DisableMap;
 
-    uint8 MAX_DISABLE_TYPES = 9;
+    uint8 MAX_DISABLE_TYPES = 10;
 }
 
 void LoadDisables()
@@ -253,6 +253,22 @@ void LoadDisables()
                 }
                 break;
             }
+            case DISABLE_TYPE_ITEM:
+            {
+                ItemEntry const* itemEntry = sItemStore.LookupEntry(entry);
+                if (!itemEntry)
+                {
+                        LOG_ERROR("sql.sql", "Item entry %u from `disables` doesn't exist in item_template, skipped.", entry);
+                        continue;
+                }
+
+                if (!flags || flags > MAX_ITEM_DISABLE_TYPE)
+                {
+                        LOG_ERROR("sql.sql", "Disable flags for item %u are invalid, skipped.", entry);
+                        continue;
+                }
+                break;
+            }
             default:
                 break;
         }
@@ -380,6 +396,7 @@ bool IsDisabledFor(DisableType type, uint32 entry, Unit const* unit, uint8 flags
         case DISABLE_TYPE_MMAP:
             return true;
         case DISABLE_TYPE_VMAP:
+        case DISABLE_TYPE_ITEM:
            return (flags & itr->second.flags) != 0;
     }
 

--- a/src/server/game/Conditions/DisableMgr.h
+++ b/src/server/game/Conditions/DisableMgr.h
@@ -32,7 +32,8 @@ enum DisableType
     DISABLE_TYPE_OUTDOORPVP             = 5,
     DISABLE_TYPE_VMAP                   = 6,
     DISABLE_TYPE_MMAP                   = 7,
-    DISABLE_TYPE_LFG_MAP                = 8
+    DISABLE_TYPE_LFG_MAP                = 8,
+    DISABLE_TYPE_ITEM                   = 9
 };
 
 enum SpellDisableTypes
@@ -47,6 +48,16 @@ enum SpellDisableTypes
     MAX_SPELL_DISABLE_TYPE = (  SPELL_DISABLE_PLAYER | SPELL_DISABLE_CREATURE | SPELL_DISABLE_PET |
                                 SPELL_DISABLE_DEPRECATED_SPELL | SPELL_DISABLE_MAP | SPELL_DISABLE_AREA |
                                 SPELL_DISABLE_LOS)
+};
+
+enum ItemDisableTypes
+{
+    ITEM_DISABLE_AUCTIONHOUSE     = 0x01,
+    ITEM_DISABLE_AUCTIONHOUSE_BOT = 0x02,
+    ITEM_DISABLE_LOOT_DROP        = 0x04,
+    ITEM_DISABLE_VENDOR           = 0x08,
+
+    MAX_ITEM_DISABLE_TYPE = (ITEM_DISABLE_AUCTIONHOUSE | ITEM_DISABLE_AUCTIONHOUSE_BOT | ITEM_DISABLE_LOOT_DROP | ITEM_DISABLE_VENDOR)
 };
 
 enum MMapDisableTypes

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -9132,6 +9132,9 @@ void ObjectMgr::LoadVendors()
         uint32 entry        = fields[0].GetUInt32();
         int32 item_id      = fields[1].GetInt32();
 
+        if (DisableMgr::IsDisabledFor(DISABLE_TYPE_ITEM, item_id, nullptr, ITEM_DISABLE_VENDOR))
+            continue;
+
         // if item is a negative, its a reference
         if (item_id < 0)
             count += LoadReferenceVendor(entry, -item_id, &skip_vendors);

--- a/src/server/game/Handlers/AuctionHouseHandler.cpp
+++ b/src/server/game/Handlers/AuctionHouseHandler.cpp
@@ -232,6 +232,12 @@ void WorldSession::HandleAuctionSellItem(WorldPacket& recvData)
         if (itemEntry == 0)
             itemEntry = item->GetTemplate()->GetId();
 
+        if (DisableMgr::IsDisabledFor(DISABLE_TYPE_ITEM, itemEntry, nullptr, ITEM_DISABLE_AUCTIONHOUSE))
+        {
+            SendAuctionCommandResult(0, AUCTION_SELL_ITEM, ERR_AUCTION_DATABASE_ERROR);
+            return;
+        }
+
         if (sAuctionMgr->GetAItem(item->GetGUID().GetCounter()) || !item->CanBeTraded() || item->IsNotEmptyBag() ||
             (item->GetTemplate()->GetFlags() & ITEM_FLAG_CONJURED) || item->GetUInt32Value(ITEM_FIELD_DURATION) ||
             item->GetCount() < count[i] || itemEntry != item->GetTemplate()->GetId())

--- a/src/server/game/Loot/Loot.cpp
+++ b/src/server/game/Loot/Loot.cpp
@@ -17,6 +17,7 @@
 
 #include "Loot.h"
 #include "DBCStores.h"
+#include "DisableMgr.h"
 #include "Group.h"
 #include "ItemEnchantmentMgr.h"
 #include "ItemTemplate.h"
@@ -76,6 +77,9 @@ bool LootItem::AllowedForPlayer(Player const* player) const
 
     ItemTemplate const* pProto = sObjectMgr->GetItemTemplate(itemid);
     if (!pProto)
+        return false;
+
+    if (DisableMgr::IsDisabledFor(DISABLE_TYPE_ITEM, itemid, nullptr, ITEM_DISABLE_LOOT_DROP))
         return false;
 
     // not show loot for players without profession or those who already know the recipe

--- a/src/server/scripts/Commands/cs_disable.cpp
+++ b/src/server/scripts/Commands/cs_disable.cpp
@@ -51,6 +51,7 @@ public:
             { "outdoorpvp",           rbac::RBAC_PERM_COMMAND_DISABLE_REMOVE_OUTDOORPVP,           true, &HandleRemoveDisableOutdoorPvPCommand,          "" },
             { "vmap",                 rbac::RBAC_PERM_COMMAND_DISABLE_REMOVE_VMAP,                 true, &HandleRemoveDisableVmapCommand,                "" },
             { "mmap",                 rbac::RBAC_PERM_COMMAND_DISABLE_REMOVE_MMAP,                 true, &HandleRemoveDisableMMapCommand,                "" },
+            { "item",                 rbac::RBAC_PERM_COMMAND_DISABLE_REMOVE_ITEM,                 true, &HandleRemoveDisableItemCommand,                "" },
         };
         static std::vector<ChatCommand> addDisableCommandTable =
         {
@@ -62,6 +63,7 @@ public:
             { "outdoorpvp",           rbac::RBAC_PERM_COMMAND_DISABLE_ADD_OUTDOORPVP,           true, &HandleAddDisableOutdoorPvPCommand,             "" },
             { "vmap",                 rbac::RBAC_PERM_COMMAND_DISABLE_ADD_VMAP,                 true, &HandleAddDisableVmapCommand,                   "" },
             { "mmap",                 rbac::RBAC_PERM_COMMAND_DISABLE_ADD_MMAP,                 true, &HandleAddDisableMMapCommand,                   "" },
+            { "item",                 rbac::RBAC_PERM_COMMAND_DISABLE_ADD_ITEM,                 true, &HandleAddDisableItemCommand,                   "" },
         };
         static std::vector<ChatCommand> disableCommandTable =
         {
@@ -183,6 +185,17 @@ public:
                 disableTypeStr = "mmap";
                 break;
             }
+            case DISABLE_TYPE_ITEM:
+            {
+                if (!sItemStore.LookupEntry(entry))
+                {
+                    handler->PSendSysMessage(LANG_COMMAND_NOITEMFOUND);
+                    handler->SetSentErrorMessage(true);
+                    return false;
+                }
+                disableTypeStr = "item";
+                break;
+            }
             default:
                 break;
         }
@@ -274,6 +287,14 @@ public:
         return HandleAddDisables(handler, args, DISABLE_TYPE_MMAP);
     }
 
+    static bool HandleAddDisableItemCommand(ChatHandler* handler, char const* args)
+    {
+        if (!*args)
+            return false;
+
+        return HandleAddDisables(handler, args, DISABLE_TYPE_ITEM);
+    }
+
     static bool HandleRemoveDisables(ChatHandler* handler, char const* args, uint8 disableType)
     {
         char* entryStr = strtok((char*)args, " ");
@@ -309,6 +330,9 @@ public:
                 break;
             case DISABLE_TYPE_MMAP:
                 disableTypeStr = "mmap";
+                break;
+            case DISABLE_TYPE_ITEM:
+                disableTypeStr = "item";
                 break;
         }
 
@@ -394,6 +418,14 @@ public:
             return false;
 
         return HandleRemoveDisables(handler, args, DISABLE_TYPE_MMAP);
+    }
+
+    static bool HandleRemoveDisableItemCommand(ChatHandler* handler, char const* args)
+    {
+        if (!*args)
+            return false;
+
+        return HandleRemoveDisables(handler, args, DISABLE_TYPE_ITEM);
     }
 };
 

--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -3706,16 +3706,6 @@ AuctionHouseBot.Class.Container.ItemLevel.Max = 0
 AuctionHouseBot.forceIncludeItems = ""
 
 #
-#    AuctionHouseBot.forceExcludeItems
-#       Description: Exclude these items even if they would pass the filters
-#                    List of ids with delimiter ','
-#       Example:     "21878,27774,27811,28117,28122,43949" (this removes old items)
-#       Default:     ""
-#
-
-AuctionHouseBot.forceExcludeItems = "6343,6345,6376"
-
-#
 #    AuctionHouseBot.Class.RandomStackRatio.*
 #       Description: Used to determine how often a stack of the class will be single or randomly-size stacked when posted
 #                    Value needs to be between 0 and 100, no decimal.  Anything higher than 100 will be treated as 100


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
### Changes proposed

- Add item disabling for Auction House (Player) & Auction House (Bot)
- Add item disabling for Loot Drops. This will allow to remove drops without removing the item from loot table.
- Add item disabling for Vendors. This removes the item from appearing in the vendor list but remains in the database.

### How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Use the SQL script below to test with the Game Master items. Testing only for Auction House, since it will be the easier to test. Make sure to reload your disable table before testing once the SQL script is added to your database.

Try adding the items listed below to the Auction House after you apply the SQL for Game Master items.

```sql
DELETE FROM disables WHERE sourcetype = 9;
INSERT INTO disables (sourcetype, entry, flags, comment) VALUES
(9,  2586, 3, 'Disable item 2586 (GameMaster\'s Robe) for Auction House Player & Bot'),
(9, 11508, 3, 'Disable item 11508 (GameMaster\'s Slippers) for Auction House Player & Bot'),
(9, 12064, 3, 'Disable item 12064 (GameMaster\'s Hood) for Auction House Player & Bot'),
(9,  7192, 2, 'Disable item 7192 (Plans: Goblin Rocket Boots) for Auction House Bot');
```

### Newly added item disable flags.
```
ITEM_DISABLE_AUCTIONHOUSE     = 0x01
ITEM_DISABLE_AUCTIONHOUSE_BOT = 0x02
ITEM_DISABLE_LOOT_DROP        = 0x04
ITEM_DISABLE_VENDOR           = 0x08
```

### Example Commands:
The idea is to make managing your server easier in the long run then by the old method. 
```
disable add item 926 1 -- This will disable Battle Axe from being sold in the auction house by player
disable add item 926 2 -- This will disable Battle Axe from being sold in the auction house by bot
disable add item 926 3 -- This will disable Battle Axe from being sold in the auction house by player & bot
```
To remove the item from being disable system, use the remove option and all data relating to item 926 will be removed.
```
disable remove item 926
```

### Known issues and TODO list
<!-- Is there anything else left to do after this PR? -->

- [x] Make the needed changes in the database with SQL update for new command


**Notice**: This feature came from MinaseCore my private project I been working on for +10 years. If you plan on to use this feature in your own project, please give credit where its due.

**Disclaimer:** I am releasing this feature under the GPL Version 2.0 license and not AGPL 3.0 license. If you wanting to release this under AGPL 3.0 license, contact me in discord here: https://discord.com/invite/GZ5rsxumxN.

---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
