### PR TITLE
update\fix (core): Creature Flags and build fix

### DIFF
--- a/src/server/game/DataStores/DBCEnums.h
+++ b/src/server/game/DataStores/DBCEnums.h
@@ -759,7 +759,7 @@ enum CurrencyTypes
     CURRENCY_TYPE_NERUBIAN_FRAGMENT                 = 400,
     CURRENCY_TYPE_TOLVIR_FRAGMENT                   = 401,
 
-    // DragonSoul 
+    // DragonSoul
     CURRENCY_TYPE_MOTE_OF_DARKNESS                  = 614,
     CURRENCY_TYPE_ESSENCE_OF_CORRUPTED_DEATHWING    = 615
 };

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -51,7 +51,7 @@ enum CreatureFlagsExtra : uint32
     CREATURE_FLAG_EXTRA_NO_COMBAT            = 0x00002000,       // creature is not allowed to enter combat
     CREATURE_FLAG_EXTRA_WORLDEVENT           = 0x00004000,       // custom flag for world event creatures (left room for merging)
     CREATURE_FLAG_EXTRA_GUARD                = 0x00008000,       // Creature is guard
-    CREATURE_FLAG_EXTRA_UNUSED_16            = 0x00010000,
+    CREATURE_FLAG_EXTRA_IGNORE_FEIGN_DEATH   = 0x00010000,       // creature ignores feign death
     CREATURE_FLAG_EXTRA_NO_CRIT              = 0x00020000,       // creature can't do critical strikes
     CREATURE_FLAG_EXTRA_NO_SKILLGAIN         = 0x00040000,       // creature won't increase weapon skills
     CREATURE_FLAG_EXTRA_TAUNT_DIMINISH       = 0x00080000,       // Taunt is a subject to diminishing returns on this creautre

--- a/src/server/game/Entities/Creature/CreatureData.h
+++ b/src/server/game/Entities/Creature/CreatureData.h
@@ -57,21 +57,19 @@ enum CreatureFlagsExtra : uint32
     CREATURE_FLAG_EXTRA_TAUNT_DIMINISH       = 0x00080000,       // Taunt is a subject to diminishing returns on this creautre
     CREATURE_FLAG_EXTRA_ALL_DIMINISH         = 0x00100000,       // creature is subject to all diminishing returns as player are
     CREATURE_FLAG_EXTRA_NO_PLAYER_DAMAGE_REQ = 0x00200000,       // creature does not need to take player damage for kill credit
-    CREATURE_FLAG_EXTRA_UNUSED_22            = 0x00400000,
-    CREATURE_FLAG_EXTRA_UNUSED_23            = 0x00800000,
-    CREATURE_FLAG_EXTRA_UNUSED_24            = 0x01000000,
-    CREATURE_FLAG_EXTRA_UNUSED_25            = 0x02000000,
-    CREATURE_FLAG_EXTRA_UNUSED_26            = 0x04000000,
-    CREATURE_FLAG_EXTRA_UNUSED_27            = 0x08000000,
+    CREATURE_FLAG_EXTRA_AVOID_AOE            = 0x00400000,       // ignored by aoe attacks (for icc blood prince council npc - Dark Nucleus)
+    CREATURE_FLAG_EXTRA_NO_DODGE             = 0x00800000,       // target cannot dodge
+    CREATURE_FLAG_EXTRA_MODULE               = 0x01000000,
+    CREATURE_FLAG_EXTRA_DONT_CALL_ASSISTANCE = 0x02000000,       // Prevent creatures from calling for assistance on initial aggro
+    CREATURE_FLAG_DONT_OVERRIDE_ENTRY_SAI    = 0x04000000,       // Load both ENTRY and GUID specific SAI
+    CREATURE_FLAG_EXTRA_UNUSED_28            = 0x08000000,
     CREATURE_FLAG_EXTRA_DUNGEON_BOSS         = 0x10000000,       // creature is a dungeon boss (SET DYNAMICALLY, DO NOT ADD IN DB)
     CREATURE_FLAG_EXTRA_IGNORE_PATHFINDING   = 0x20000000,       // creature ignore pathfinding
     CREATURE_FLAG_EXTRA_IMMUNITY_KNOCKBACK   = 0x40000000,       // creature is immune to knockback effects
-    CREATURE_FLAG_EXTRA_UNUSED_31            = 0x80000000,
+    CREATURE_FLAG_EXTRA_HARD_RESET           = 0x80000000,
 
     // Masks
-    CREATURE_FLAG_EXTRA_UNUSED               = (CREATURE_FLAG_EXTRA_UNUSED_16 | CREATURE_FLAG_EXTRA_UNUSED_22 |
-                                                CREATURE_FLAG_EXTRA_UNUSED_23 | CREATURE_FLAG_EXTRA_UNUSED_24 | CREATURE_FLAG_EXTRA_UNUSED_25 |
-                                                CREATURE_FLAG_EXTRA_UNUSED_26 | CREATURE_FLAG_EXTRA_UNUSED_27 | CREATURE_FLAG_EXTRA_UNUSED_31),
+    CREATURE_FLAG_EXTRA_UNUSED = (CREATURE_FLAG_EXTRA_UNUSED_28), // SKIP
 
     CREATURE_FLAG_EXTRA_DB_ALLOWED           = (0xFFFFFFFF & ~(CREATURE_FLAG_EXTRA_UNUSED | CREATURE_FLAG_EXTRA_DUNGEON_BOSS))
 };
@@ -118,9 +116,9 @@ struct FC_GAME_API CreatureMovementData
     bool IsSwimAllowed() const { return Swim; }
     bool IsFlightAllowed() const { return Flight != CreatureFlightMovementType::None; }
     bool IsRooted() const { return Rooted; }
-    bool IsGravityDisabled() const { return  Flight == CreatureFlightMovementType::DisableGravity; }
-    bool CanFly() const { return  Flight == CreatureFlightMovementType::CanFly; }
-    bool IsHoverEnabled() const { return  Ground == CreatureGroundMovementType::Hover; }
+    bool IsGravityDisabled() const { return Flight == CreatureFlightMovementType::DisableGravity; }
+    bool CanFly() const { return Flight == CreatureFlightMovementType::CanFly; }
+    bool IsHoverEnabled() const { return Ground == CreatureGroundMovementType::Hover; }
 
     CreatureRandomMovementType GetRandom() const { return Random; }
 
@@ -139,74 +137,74 @@ static uint32 const MAX_CREATURE_SPELLS = 8;
 // from `creature_template` table
 struct FC_GAME_API CreatureTemplate
 {
-    uint32  Entry;
-    uint32  DifficultyEntry[MAX_DIFFICULTY - 1];
-    uint32  KillCredit[MAX_KILL_CREDIT];
-    uint32  Modelid1;
-    uint32  Modelid2;
-    uint32  Modelid3;
-    uint32  Modelid4;
-    std::string  Name;
+    uint32 Entry;
+    uint32 DifficultyEntry[MAX_DIFFICULTY - 1];
+    uint32 KillCredit[MAX_KILL_CREDIT];
+    uint32 Modelid1;
+    uint32 Modelid2;
+    uint32 Modelid3;
+    uint32 Modelid4;
+    std::string Name;
     std::string FemaleName;
-    std::string  Title;
-    std::string  IconName;
-    uint32  GossipMenuId;
-    uint8   minlevel;
-    uint8   maxlevel;
-    uint32  expansion;
-    uint32  expansionUnknown;                               // either 0 or 3, sent to the client / wdb
-    uint32  faction;
-    uint32  npcflag;
-    float   speed_walk;
-    float   speed_run;
-    float   scale;
-    uint32  rank;
-    uint32  dmgschool;
-    uint32  BaseAttackTime;
-    uint32  RangeAttackTime;
-    float   BaseVariance;
-    float   RangeVariance;
-    uint32  unit_class;                                     // enum Classes. Note only 4 classes are known for creatures.
-    uint32  unit_flags;                                     // enum UnitFlags mask values
-    uint32  unit_flags2;                                    // enum UnitFlags2 mask values
-    uint32  dynamicflags;
-    CreatureFamily  family;                                 // enum CreatureFamily values (optional)
-    uint32  trainer_class;
-    uint32  type;                                           // enum CreatureType values
-    uint32  type_flags;                                     // enum CreatureTypeFlags mask values
-    uint32  type_flags2;                                    // unknown enum, only set for 4 creatures (with value 1)
-    uint32  lootid;
-    uint32  pickpocketLootId;
-    uint32  SkinLootId;
-    int32   resistance[MAX_SPELL_SCHOOL];
-    uint32  spells[MAX_CREATURE_SPELLS];
-    uint32  PetSpellDataId;
-    uint32  VehicleId;
-    uint32  mingold;
-    uint32  maxgold;
+    std::string Title;
+    std::string IconName;
+    uint32 GossipMenuId;
+    uint8 minlevel;
+    uint8 maxlevel;
+    uint32 expansion;
+    uint32 expansionUnknown; // either 0 or 3, sent to the client / wdb
+    uint32 faction;
+    uint32 npcflag;
+    float speed_walk;
+    float speed_run;
+    float scale;
+    uint32 rank;
+    uint32 dmgschool;
+    uint32 BaseAttackTime;
+    uint32 RangeAttackTime;
+    float BaseVariance;
+    float RangeVariance;
+    uint32 unit_class;  // enum Classes. Note only 4 classes are known for creatures.
+    uint32 unit_flags;  // enum UnitFlags mask values
+    uint32 unit_flags2; // enum UnitFlags2 mask values
+    uint32 dynamicflags;
+    CreatureFamily family; // enum CreatureFamily values (optional)
+    uint32 trainer_class;
+    uint32 type;        // enum CreatureType values
+    uint32 type_flags;  // enum CreatureTypeFlags mask values
+    uint32 type_flags2; // unknown enum, only set for 4 creatures (with value 1)
+    uint32 lootid;
+    uint32 pickpocketLootId;
+    uint32 SkinLootId;
+    int32 resistance[MAX_SPELL_SCHOOL];
+    uint32 spells[MAX_CREATURE_SPELLS];
+    uint32 PetSpellDataId;
+    uint32 VehicleId;
+    uint32 mingold;
+    uint32 maxgold;
     std::string AIName;
-    uint32  MovementType;
+    uint32 MovementType;
     CreatureMovementData Movement;
-    float   HoverHeight;
-    float   ModHealth;
-    float   ModHealthExtra;
-    float   ModMana;
-    float   ModManaExtra;                                   // Added in 4.x, this value is usually 2 for a small group of creatures with double mana
-    float   ModArmor;
-    float   ModDamage;
-    float   ModExperience;
-    bool    RacialLeader;
-    uint32  movementId;
-    bool    RegenHealth;
-    uint32  MechanicImmuneMask;
-    uint32  SpellSchoolImmuneMask;
-    uint32  flags_extra;
-    uint32  ScriptID;
+    float HoverHeight;
+    float ModHealth;
+    float ModHealthExtra;
+    float ModMana;
+    float ModManaExtra; // Added in 4.x, this value is usually 2 for a small group of creatures with double mana
+    float ModArmor;
+    float ModDamage;
+    float ModExperience;
+    bool RacialLeader;
+    uint32 movementId;
+    bool RegenHealth;
+    uint32 MechanicImmuneMask;
+    uint32 SpellSchoolImmuneMask;
+    uint32 flags_extra;
+    uint32 ScriptID;
     WorldPacket QueryData[TOTAL_LOCALES];
-    uint32  GetRandomValidModelId() const;
-    uint32  GetFirstValidModelId() const;
-    uint32  GetFirstInvisibleModel() const;
-    uint32  GetFirstVisibleModel() const;
+    uint32 GetRandomValidModelId() const;
+    uint32 GetFirstValidModelId() const;
+    uint32 GetFirstInvisibleModel() const;
+    uint32 GetFirstVisibleModel() const;
 
     // helpers
     SkillType GetRequiredLootSkill() const
@@ -218,13 +216,10 @@ struct FC_GAME_API CreatureTemplate
         else if (type_flags & CREATURE_TYPE_FLAG_ENGINEERING_SKINNING_SKILL)
             return SKILL_ENGINEERING;
         else
-            return SKILL_SKINNING;                          // normal case
+            return SKILL_SKINNING; // normal case
     }
 
-    bool IsExotic() const
-    {
-        return (type_flags & CREATURE_TYPE_FLAG_EXOTIC_PET) != 0;
-    }
+    bool IsExotic() const { return (type_flags & CREATURE_TYPE_FLAG_EXOTIC_PET) != 0; }
 
     bool IsTameable(bool canTameExotic) const
     {
@@ -253,10 +248,7 @@ struct FC_GAME_API CreatureBaseStats
 
     // Helpers
 
-    uint32 GenerateHealth(CreatureTemplate const* info) const
-    {
-        return uint32(ceil(BaseHealth[info->expansion] * info->ModHealth * info->ModHealthExtra));
-    }
+    uint32 GenerateHealth(CreatureTemplate const* info) const { return uint32(ceil(BaseHealth[info->expansion] * info->ModHealth * info->ModHealthExtra)); }
 
     uint32 GenerateMana(CreatureTemplate const* info) const
     {
@@ -267,15 +259,9 @@ struct FC_GAME_API CreatureBaseStats
         return uint32(ceil(BaseMana * info->ModMana * info->ModManaExtra));
     }
 
-    uint32 GenerateArmor(CreatureTemplate const* info) const
-    {
-        return uint32(ceil(BaseArmor * info->ModArmor));
-    }
+    uint32 GenerateArmor(CreatureTemplate const* info) const { return uint32(ceil(BaseArmor * info->ModArmor)); }
 
-    float GenerateBaseDamage(CreatureTemplate const* info) const
-    {
-        return BaseDamage[info->expansion];
-    }
+    float GenerateBaseDamage(CreatureTemplate const* info) const { return BaseDamage[info->expansion]; }
 
     static CreatureBaseStats const* GetBaseStats(uint8 level, uint8 unitClass);
 };
@@ -291,13 +277,13 @@ struct CreatureLocale
 
 struct EquipmentInfo
 {
-    uint32  ItemEntry[MAX_EQUIPMENT_ITEMS];
+    uint32 ItemEntry[MAX_EQUIPMENT_ITEMS];
 };
 
 // from `creature` table
 struct CreatureData : public SpawnData
 {
-    CreatureData() : SpawnData(SPAWN_TYPE_CREATURE) { }
+    CreatureData() : SpawnData(SPAWN_TYPE_CREATURE) {}
     uint32 displayid = 0;
     int8 equipmentId = 0;
     float spawndist = 0.0f;
@@ -322,9 +308,9 @@ struct CreatureModelInfo
 enum InhabitTypeValues
 {
     INHABIT_GROUND = 1,
-    INHABIT_WATER  = 2,
-    INHABIT_AIR    = 4,
-    INHABIT_ROOT   = 8,
+    INHABIT_WATER = 2,
+    INHABIT_AIR = 4,
+    INHABIT_ROOT = 8,
     INHABIT_ANYWHERE = INHABIT_GROUND | INHABIT_WATER | INHABIT_AIR | INHABIT_ROOT
 };
 
@@ -349,16 +335,16 @@ struct CreatureAddon
 // Vendors
 struct VendorItem
 {
-    VendorItem() : item(0), maxcount(0), incrtime(0), ExtendedCost(0), Type(0), PlayerConditionId(0) { }
+    VendorItem() : item(0), maxcount(0), incrtime(0), ExtendedCost(0), Type(0), PlayerConditionId(0) {}
 
     uint32 item;
-    uint32 maxcount;                                        // 0 for infinity item amount
-    uint32 incrtime;                                        // time for restore items amount if maxcount != 0
+    uint32 maxcount; // 0 for infinity item amount
+    uint32 incrtime; // time for restore items amount if maxcount != 0
     uint32 ExtendedCost;
-    uint8  Type;
+    uint8 Type;
     uint32 PlayerConditionId;
 
-    //helpers
+    // helpers
     bool IsGoldRequired(ItemTemplate const* pProto) const;
 };
 
@@ -375,16 +361,10 @@ struct VendorItemData
     }
     bool Empty() const { return m_items.empty(); }
     uint32 GetItemCount() const { return m_items.size(); }
-    void AddItem(VendorItem vItem)
-    {
-        m_items.emplace_back(std::move(vItem));
-    }
+    void AddItem(VendorItem vItem) { m_items.emplace_back(std::move(vItem)); }
     bool RemoveItem(uint32 item_id, uint8 type);
     VendorItem const* FindItemCostPair(uint32 item_id, uint32 extendedCost, uint8 type) const;
-    void Clear()
-    {
-        m_items.clear();
-    }
+    void Clear() { m_items.clear(); }
 };
 
 typedef std::unordered_map<uint32, float /*SparringHealthLimit*/> CreatureSparringTemplateMap;
@@ -404,7 +384,7 @@ struct CreatureSpellFocusData
     ObjectGuid OriginalUnitTarget;
     uint32 ReacquiringTargetDelay = 0;
 
-public:
+  public:
     void Reset()
     {
         FocusSpell = nullptr;

--- a/src/server/scripts/Kalimdor/CavernsOfTime/DragonSoul/boss_morchok.cpp
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/DragonSoul/boss_morchok.cpp
@@ -16,7 +16,7 @@
 #include "Vehicle.h"
 
 // clang-format off
-enum Dialogs 
+enum Dialogs
 {
     TALK_EVENT_GROUP_ONE                = 0,
     TALK_EVENT_GROUP_ONE_2              = 1,
@@ -85,7 +85,7 @@ enum Phases
     PHASE_TWO = 2
 };
 
-enum VehicleTargetHandling 
+enum VehicleTargetHandling
 {
     DATA_VEHICLE_TARGET    = 100,
     VEHICLE_TARGET_MORCHOK = 200,

--- a/src/server/scripts/Kalimdor/CavernsOfTime/DragonSoul/dragon_soul.h
+++ b/src/server/scripts/Kalimdor/CavernsOfTime/DragonSoul/dragon_soul.h
@@ -118,7 +118,7 @@ enum DSCreatures
     NPC_HIDEOUS_AMALGAMATION                    = 53890,
     NPC_BURNING_TENDONS_L                       = 56575,
     NPC_BURNING_TENDONS_R                       = 56341,
-    
+
     /*Madness of Deathwing*/
     NPC_DEATHWING_MADNESS_OF_DEATHWING          = 57962,
     NPC_ARM_TENTACLE_1                          = 56167,


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
This is pretty much a cherry pick from the WIP PR for the chess event. Alot of flags were not able to utilized because it was marked as unused and fell under the creature_flag_extra_unused. so we label them thru known RE flags from previous projects and adjust the extra unused flag settings.

### Changes proposed

- update creature flags
- source only change

### Issues addressed
<!-- If your fix has a relating issue, link it below -->

- Closes None Reported

### Known issues and TODO list
<!-- Is there anything else left to do after this PR? -->

- [ ] 
- [ ] 

---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
