### PR TITLE
feat: adding rbac permissions when set gm level

### DIFF
--- a/src/server/game/Accounts/AccountMgr.cpp
+++ b/src/server/game/Accounts/AccountMgr.cpp
@@ -29,553 +29,557 @@
 #include "World.h"
 #include "WorldSession.h"
 
+std::map<uint32, uint32> accountAccessMap = {{SEC_PLAYER, 195}, {SEC_MODERATOR, 194}, {SEC_GAMEMASTER, 193}, {SEC_ADMINISTRATOR, 192}};
+
 AccountMgr::AccountMgr() {}
 
 AccountMgr::~AccountMgr() { ClearRBAC(); }
 
-AccountMgr *AccountMgr::instance() {
-  static AccountMgr instance;
-  return &instance;
+AccountMgr* AccountMgr::instance()
+{
+    static AccountMgr instance;
+    return &instance;
 }
 
-AccountOpResult AccountMgr::CreateAccount(std::string username,
-                                          std::string password,
-                                          std::string email /*= ""*/) {
-  if (utf8length(username) > MAX_ACCOUNT_STR)
-    return AccountOpResult::AOR_NAME_TOO_LONG; // username's too long
+AccountOpResult AccountMgr::CreateAccount(std::string username, std::string password, std::string email /*= ""*/)
+{
+    if (utf8length(username) > MAX_ACCOUNT_STR)
+        return AccountOpResult::AOR_NAME_TOO_LONG; // username's too long
 
-  if (utf8length(password) > MAX_PASS_STR)
-    return AccountOpResult::AOR_PASS_TOO_LONG; // password's too long
+    if (utf8length(password) > MAX_PASS_STR)
+        return AccountOpResult::AOR_PASS_TOO_LONG; // password's too long
 
-  Utf8ToUpperOnlyLatin(username);
-  Utf8ToUpperOnlyLatin(password);
-  Utf8ToUpperOnlyLatin(email);
+    Utf8ToUpperOnlyLatin(username);
+    Utf8ToUpperOnlyLatin(password);
+    Utf8ToUpperOnlyLatin(email);
 
-  if (GetId(username))
-    return AccountOpResult::AOR_NAME_ALREADY_EXIST; // username does already
-                                                    // exist
+    if (GetId(username))
+        return AccountOpResult::AOR_NAME_ALREADY_EXIST; // username does already
+                                                        // exist
 
-  LoginDatabasePreparedStatement *stmt =
-      LoginDatabase.GetPreparedStatement(LOGIN_INS_ACCOUNT);
+    LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_INS_ACCOUNT);
 
-  stmt->setString(0, username);
-  stmt->setString(1, CalculateShaPassHash(username, password));
-  stmt->setString(2, email);
-  stmt->setString(3, email);
+    stmt->setString(0, username);
+    stmt->setString(1, CalculateShaPassHash(username, password));
+    stmt->setString(2, email);
+    stmt->setString(3, email);
 
-  LoginDatabase.DirectExecute(
-      stmt); // Enforce saving, otherwise AddGroup can fail
+    LoginDatabase.DirectExecute(stmt); // Enforce saving, otherwise AddGroup can fail
 
-  stmt = LoginDatabase.GetPreparedStatement(LOGIN_INS_REALM_CHARACTERS_INIT);
-  LoginDatabase.Execute(stmt);
+    stmt = LoginDatabase.GetPreparedStatement(LOGIN_INS_REALM_CHARACTERS_INIT);
+    LoginDatabase.Execute(stmt);
 
-  return AccountOpResult::AOR_OK; // everything's fine
+    return AccountOpResult::AOR_OK; // everything's fine
 }
 
-AccountOpResult AccountMgr::DeleteAccount(uint32 accountId) {
-  // Check if accounts exists
-  LoginDatabasePreparedStatement *loginStmt =
-      LoginDatabase.GetPreparedStatement(LOGIN_SEL_ACCOUNT_BY_ID);
-  loginStmt->setUInt32(0, accountId);
-  PreparedQueryResult result = LoginDatabase.Query(loginStmt);
+AccountOpResult AccountMgr::DeleteAccount(uint32 accountId)
+{
+    // Check if accounts exists
+    LoginDatabasePreparedStatement* loginStmt = LoginDatabase.GetPreparedStatement(LOGIN_SEL_ACCOUNT_BY_ID);
+    loginStmt->setUInt32(0, accountId);
+    PreparedQueryResult result = LoginDatabase.Query(loginStmt);
 
-  if (!result)
-    return AccountOpResult::AOR_NAME_NOT_EXIST;
+    if (!result)
+        return AccountOpResult::AOR_NAME_NOT_EXIST;
 
-  // Obtain accounts characters
-  CharacterDatabasePreparedStatement *stmt =
-      CharacterDatabase.GetPreparedStatement(CHAR_SEL_CHARS_BY_ACCOUNT_ID);
+    // Obtain accounts characters
+    CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_CHARS_BY_ACCOUNT_ID);
 
-  stmt->setUInt32(0, accountId);
+    stmt->setUInt32(0, accountId);
 
-  result = CharacterDatabase.Query(stmt);
+    result = CharacterDatabase.Query(stmt);
 
-  if (result) {
-    do {
-      ObjectGuid guid(HighGuid::Player, (*result)[0].GetUInt32());
+    if (result)
+    {
+        do
+        {
+            ObjectGuid guid(HighGuid::Player, (*result)[0].GetUInt32());
 
-      // Kick if player is online
-      if (Player *p = ObjectAccessor::FindConnectedPlayer(guid)) {
-        WorldSession *s = p->GetSession();
-        s->KickPlayer(); // mark session to remove at next session list update
-        s->LogoutPlayer(
-            false); // logout player without waiting next session list update
-      }
+            // Kick if player is online
+            if (Player* p = ObjectAccessor::FindConnectedPlayer(guid))
+            {
+                WorldSession* s = p->GetSession();
+                s->KickPlayer();        // mark session to remove at next session list update
+                s->LogoutPlayer(false); // logout player without waiting next session list update
+            }
 
-      Player::DeleteFromDB(guid, accountId,
-                           false); // no need to update realm characters
+            Player::DeleteFromDB(guid, accountId,
+                false); // no need to update realm characters
+        } while (result->NextRow());
+    }
+
+    // table realm specific but common for all characters of account for realm
+    stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_TUTORIALS);
+    stmt->setUInt32(0, accountId);
+    CharacterDatabase.Execute(stmt);
+
+    stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_ACCOUNT_DATA);
+    stmt->setUInt32(0, accountId);
+    CharacterDatabase.Execute(stmt);
+
+    stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_CHARACTER_BAN);
+    stmt->setUInt32(0, accountId);
+    CharacterDatabase.Execute(stmt);
+
+    LoginDatabaseTransaction trans = LoginDatabase.BeginTransaction();
+
+    loginStmt = LoginDatabase.GetPreparedStatement(LOGIN_DEL_ACCOUNT);
+    loginStmt->setUInt32(0, accountId);
+    trans->Append(loginStmt);
+
+    loginStmt = LoginDatabase.GetPreparedStatement(LOGIN_DEL_ACCOUNT_ACCESS);
+    loginStmt->setUInt32(0, accountId);
+    trans->Append(loginStmt);
+
+    loginStmt = LoginDatabase.GetPreparedStatement(LOGIN_DEL_REALM_CHARACTERS);
+    loginStmt->setUInt32(0, accountId);
+    trans->Append(loginStmt);
+
+    loginStmt = LoginDatabase.GetPreparedStatement(LOGIN_DEL_ACCOUNT_BANNED);
+    loginStmt->setUInt32(0, accountId);
+    trans->Append(loginStmt);
+
+    loginStmt = LoginDatabase.GetPreparedStatement(LOGIN_DEL_ACCOUNT_MUTED);
+    loginStmt->setUInt32(0, accountId);
+    trans->Append(loginStmt);
+
+    LoginDatabase.CommitTransaction(trans);
+
+    return AccountOpResult::AOR_OK;
+}
+
+AccountOpResult AccountMgr::ChangeUsername(uint32 accountId, std::string newUsername, std::string newPassword)
+{
+    // Check if accounts exists
+    LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_SEL_ACCOUNT_BY_ID);
+    stmt->setUInt32(0, accountId);
+    PreparedQueryResult result = LoginDatabase.Query(stmt);
+
+    if (!result)
+        return AccountOpResult::AOR_NAME_NOT_EXIST;
+
+    if (utf8length(newUsername) > MAX_ACCOUNT_STR)
+        return AccountOpResult::AOR_NAME_TOO_LONG;
+
+    if (utf8length(newPassword) > MAX_ACCOUNT_STR)
+        return AccountOpResult::AOR_PASS_TOO_LONG;
+
+    Utf8ToUpperOnlyLatin(newUsername);
+    Utf8ToUpperOnlyLatin(newPassword);
+
+    stmt = LoginDatabase.GetPreparedStatement(LOGIN_UPD_USERNAME);
+
+    stmt->setString(0, newUsername);
+    stmt->setString(1, CalculateShaPassHash(newUsername, newPassword));
+    stmt->setUInt32(2, accountId);
+
+    LoginDatabase.Execute(stmt);
+
+    return AccountOpResult::AOR_OK;
+}
+
+AccountOpResult AccountMgr::ChangePassword(uint32 accountId, std::string newPassword)
+{
+    std::string username;
+
+    if (!GetName(accountId, username))
+    {
+        sScriptMgr->OnFailedPasswordChange(accountId);
+        return AccountOpResult::AOR_NAME_NOT_EXIST; // account doesn't exist
+    }
+
+    if (utf8length(newPassword) > MAX_ACCOUNT_STR)
+    {
+        sScriptMgr->OnFailedPasswordChange(accountId);
+        return AccountOpResult::AOR_PASS_TOO_LONG;
+    }
+
+    Utf8ToUpperOnlyLatin(username);
+    Utf8ToUpperOnlyLatin(newPassword);
+
+    LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_UPD_PASSWORD);
+
+    stmt->setString(0, CalculateShaPassHash(username, newPassword));
+    stmt->setUInt32(1, accountId);
+
+    LoginDatabase.Execute(stmt);
+
+    stmt = LoginDatabase.GetPreparedStatement(LOGIN_UPD_VS);
+
+    stmt->setString(0, "");
+    stmt->setString(1, "");
+    stmt->setString(2, username);
+
+    LoginDatabase.Execute(stmt);
+
+    sScriptMgr->OnPasswordChange(accountId);
+    return AccountOpResult::AOR_OK;
+}
+
+AccountOpResult AccountMgr::ChangeEmail(uint32 accountId, std::string newEmail)
+{
+    std::string username;
+
+    if (!GetName(accountId, username))
+    {
+        sScriptMgr->OnFailedEmailChange(accountId);
+        return AccountOpResult::AOR_NAME_NOT_EXIST; // account doesn't exist
+    }
+
+    if (utf8length(newEmail) > MAX_EMAIL_STR)
+    {
+        sScriptMgr->OnFailedEmailChange(accountId);
+        return AccountOpResult::AOR_EMAIL_TOO_LONG;
+    }
+
+    Utf8ToUpperOnlyLatin(username);
+    Utf8ToUpperOnlyLatin(newEmail);
+
+    LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_UPD_EMAIL);
+
+    stmt->setString(0, newEmail);
+    stmt->setUInt32(1, accountId);
+
+    LoginDatabase.Execute(stmt);
+
+    sScriptMgr->OnEmailChange(accountId);
+    return AccountOpResult::AOR_OK;
+}
+
+AccountOpResult AccountMgr::ChangeRegEmail(uint32 accountId, std::string newEmail)
+{
+    std::string username;
+
+    if (!GetName(accountId, username))
+        return AccountOpResult::AOR_NAME_NOT_EXIST; // account doesn't exist
+
+    if (utf8length(newEmail) > MAX_EMAIL_STR)
+    {
+        sScriptMgr->OnFailedEmailChange(accountId);
+        return AccountOpResult::AOR_EMAIL_TOO_LONG;
+    }
+
+    Utf8ToUpperOnlyLatin(username);
+    Utf8ToUpperOnlyLatin(newEmail);
+
+    LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_UPD_REG_EMAIL);
+
+    stmt->setString(0, newEmail);
+    stmt->setUInt32(1, accountId);
+
+    LoginDatabase.Execute(stmt);
+
+    sScriptMgr->OnEmailChange(accountId);
+    return AccountOpResult::AOR_OK;
+}
+
+uint32 AccountMgr::GetId(std::string const& username)
+{
+    LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_GET_ACCOUNT_ID_BY_USERNAME);
+    stmt->setString(0, username);
+    PreparedQueryResult result = LoginDatabase.Query(stmt);
+
+    return (result) ? (*result)[0].GetUInt32() : 0;
+}
+
+uint32 AccountMgr::GetSecurity(uint32 accountId, int32 realmId)
+{
+    LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_GET_GMLEVEL_BY_REALMID);
+    stmt->setUInt32(0, accountId);
+    stmt->setInt32(1, realmId);
+    PreparedQueryResult result = LoginDatabase.Query(stmt);
+
+    return (result) ? (*result)[0].GetUInt8() : uint32(SEC_PLAYER);
+}
+
+QueryCallback AccountMgr::GetSecurityAsync(uint32 accountId, int32 realmId, std::function<void(uint32)> callback)
+{
+    LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_GET_GMLEVEL_BY_REALMID);
+    stmt->setUInt32(0, accountId);
+    stmt->setInt32(1, realmId);
+    return LoginDatabase.AsyncQuery(stmt).WithPreparedCallback(
+        [callback = std::move(callback)](PreparedQueryResult result) { callback(result ? uint32((*result)[0].GetUInt8()) : uint32(SEC_PLAYER)); });
+}
+
+bool AccountMgr::GetName(uint32 accountId, std::string& name)
+{
+    LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_GET_USERNAME_BY_ID);
+    stmt->setUInt32(0, accountId);
+    PreparedQueryResult result = LoginDatabase.Query(stmt);
+
+    if (result)
+    {
+        name = (*result)[0].GetString();
+        return true;
+    }
+
+    return false;
+}
+
+bool AccountMgr::GetEmail(uint32 accountId, std::string& email)
+{
+    LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_GET_EMAIL_BY_ID);
+    stmt->setUInt32(0, accountId);
+    PreparedQueryResult result = LoginDatabase.Query(stmt);
+
+    if (result)
+    {
+        email = (*result)[0].GetString();
+        return true;
+    }
+
+    return false;
+}
+
+bool AccountMgr::CheckPassword(uint32 accountId, std::string password)
+{
+    std::string username;
+
+    if (!GetName(accountId, username))
+        return false;
+
+    Utf8ToUpperOnlyLatin(username);
+    Utf8ToUpperOnlyLatin(password);
+
+    LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_SEL_CHECK_PASSWORD);
+    stmt->setUInt32(0, accountId);
+    stmt->setString(1, CalculateShaPassHash(username, password));
+    PreparedQueryResult result = LoginDatabase.Query(stmt);
+
+    return (result) ? true : false;
+}
+
+bool AccountMgr::CheckEmail(uint32 accountId, std::string newEmail)
+{
+    std::string oldEmail;
+
+    // We simply return false for a non-existing email
+    if (!GetEmail(accountId, oldEmail))
+        return false;
+
+    Utf8ToUpperOnlyLatin(oldEmail);
+    Utf8ToUpperOnlyLatin(newEmail);
+
+    if (strcmp(oldEmail.c_str(), newEmail.c_str()) == 0)
+        return true;
+
+    return false;
+}
+
+uint32 AccountMgr::GetCharactersCount(uint32 accountId)
+{
+    // check character count
+    CharacterDatabasePreparedStatement* stmt = CharacterDatabase.GetPreparedStatement(CHAR_SEL_SUM_CHARS);
+    stmt->setUInt32(0, accountId);
+    PreparedQueryResult result = CharacterDatabase.Query(stmt);
+
+    return (result) ? (*result)[0].GetUInt64() : 0;
+}
+
+std::string AccountMgr::CalculateShaPassHash(std::string const& name, std::string const& password)
+{
+    SHA1Hash sha;
+    sha.Initialize();
+    sha.UpdateData(name);
+    sha.UpdateData(":");
+    sha.UpdateData(password);
+    sha.Finalize();
+
+    return ByteArrayToHexStr(sha.GetDigest(), sha.GetLength());
+}
+
+bool AccountMgr::IsBannedAccount(std::string const& name)
+{
+    LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_SEL_ACCOUNT_BANNED_BY_USERNAME);
+    stmt->setString(0, name);
+    PreparedQueryResult result = LoginDatabase.Query(stmt);
+
+    if (!result)
+        return false;
+
+    return true;
+}
+
+bool AccountMgr::IsPlayerAccount(uint32 gmlevel) { return gmlevel == SEC_PLAYER; }
+
+bool AccountMgr::IsAdminAccount(uint32 gmlevel) { return gmlevel >= SEC_ADMINISTRATOR && gmlevel <= SEC_CONSOLE; }
+
+bool AccountMgr::IsConsoleAccount(uint32 gmlevel) { return gmlevel == SEC_CONSOLE; }
+
+void AccountMgr::LoadRBAC()
+{
+    ClearRBAC();
+
+    LOG_DEBUG("rbac", "AccountMgr::LoadRBAC");
+    uint32 oldMSTime = getMSTime();
+    uint32 count1 = 0;
+    uint32 count2 = 0;
+    uint32 count3 = 0;
+
+    LOG_DEBUG("rbac", "AccountMgr::LoadRBAC: Loading permissions");
+    QueryResult result = LoginDatabase.Query("SELECT id, name FROM rbac_permissions");
+    if (!result)
+    {
+        LOG_INFO("server.loading", ">> Loaded 0 account permission definitions. "
+                                   "DB table `rbac_permissions` is empty.");
+        return;
+    }
+
+    do
+    {
+        Field* field = result->Fetch();
+        uint32 id = field[0].GetUInt32();
+        _permissions[id] = new rbac::RBACPermission(id, field[1].GetString());
+        ++count1;
     } while (result->NextRow());
-  }
 
-  // table realm specific but common for all characters of account for realm
-  stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_TUTORIALS);
-  stmt->setUInt32(0, accountId);
-  CharacterDatabase.Execute(stmt);
-
-  stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_ACCOUNT_DATA);
-  stmt->setUInt32(0, accountId);
-  CharacterDatabase.Execute(stmt);
-
-  stmt = CharacterDatabase.GetPreparedStatement(CHAR_DEL_CHARACTER_BAN);
-  stmt->setUInt32(0, accountId);
-  CharacterDatabase.Execute(stmt);
-
-  LoginDatabaseTransaction trans = LoginDatabase.BeginTransaction();
-
-  loginStmt = LoginDatabase.GetPreparedStatement(LOGIN_DEL_ACCOUNT);
-  loginStmt->setUInt32(0, accountId);
-  trans->Append(loginStmt);
-
-  loginStmt = LoginDatabase.GetPreparedStatement(LOGIN_DEL_ACCOUNT_ACCESS);
-  loginStmt->setUInt32(0, accountId);
-  trans->Append(loginStmt);
-
-  loginStmt = LoginDatabase.GetPreparedStatement(LOGIN_DEL_REALM_CHARACTERS);
-  loginStmt->setUInt32(0, accountId);
-  trans->Append(loginStmt);
-
-  loginStmt = LoginDatabase.GetPreparedStatement(LOGIN_DEL_ACCOUNT_BANNED);
-  loginStmt->setUInt32(0, accountId);
-  trans->Append(loginStmt);
-
-  loginStmt = LoginDatabase.GetPreparedStatement(LOGIN_DEL_ACCOUNT_MUTED);
-  loginStmt->setUInt32(0, accountId);
-  trans->Append(loginStmt);
-
-  LoginDatabase.CommitTransaction(trans);
-
-  return AccountOpResult::AOR_OK;
-}
-
-AccountOpResult AccountMgr::ChangeUsername(uint32 accountId,
-                                           std::string newUsername,
-                                           std::string newPassword) {
-  // Check if accounts exists
-  LoginDatabasePreparedStatement *stmt =
-      LoginDatabase.GetPreparedStatement(LOGIN_SEL_ACCOUNT_BY_ID);
-  stmt->setUInt32(0, accountId);
-  PreparedQueryResult result = LoginDatabase.Query(stmt);
-
-  if (!result)
-    return AccountOpResult::AOR_NAME_NOT_EXIST;
-
-  if (utf8length(newUsername) > MAX_ACCOUNT_STR)
-    return AccountOpResult::AOR_NAME_TOO_LONG;
-
-  if (utf8length(newPassword) > MAX_ACCOUNT_STR)
-    return AccountOpResult::AOR_PASS_TOO_LONG;
-
-  Utf8ToUpperOnlyLatin(newUsername);
-  Utf8ToUpperOnlyLatin(newPassword);
-
-  stmt = LoginDatabase.GetPreparedStatement(LOGIN_UPD_USERNAME);
-
-  stmt->setString(0, newUsername);
-  stmt->setString(1, CalculateShaPassHash(newUsername, newPassword));
-  stmt->setUInt32(2, accountId);
-
-  LoginDatabase.Execute(stmt);
-
-  return AccountOpResult::AOR_OK;
-}
-
-AccountOpResult AccountMgr::ChangePassword(uint32 accountId,
-                                           std::string newPassword) {
-  std::string username;
-
-  if (!GetName(accountId, username)) {
-    sScriptMgr->OnFailedPasswordChange(accountId);
-    return AccountOpResult::AOR_NAME_NOT_EXIST; // account doesn't exist
-  }
-
-  if (utf8length(newPassword) > MAX_ACCOUNT_STR) {
-    sScriptMgr->OnFailedPasswordChange(accountId);
-    return AccountOpResult::AOR_PASS_TOO_LONG;
-  }
-
-  Utf8ToUpperOnlyLatin(username);
-  Utf8ToUpperOnlyLatin(newPassword);
-
-  LoginDatabasePreparedStatement *stmt =
-      LoginDatabase.GetPreparedStatement(LOGIN_UPD_PASSWORD);
-
-  stmt->setString(0, CalculateShaPassHash(username, newPassword));
-  stmt->setUInt32(1, accountId);
-
-  LoginDatabase.Execute(stmt);
-
-  stmt = LoginDatabase.GetPreparedStatement(LOGIN_UPD_VS);
-
-  stmt->setString(0, "");
-  stmt->setString(1, "");
-  stmt->setString(2, username);
-
-  LoginDatabase.Execute(stmt);
-
-  sScriptMgr->OnPasswordChange(accountId);
-  return AccountOpResult::AOR_OK;
-}
-
-AccountOpResult AccountMgr::ChangeEmail(uint32 accountId,
-                                        std::string newEmail) {
-  std::string username;
-
-  if (!GetName(accountId, username)) {
-    sScriptMgr->OnFailedEmailChange(accountId);
-    return AccountOpResult::AOR_NAME_NOT_EXIST; // account doesn't exist
-  }
-
-  if (utf8length(newEmail) > MAX_EMAIL_STR) {
-    sScriptMgr->OnFailedEmailChange(accountId);
-    return AccountOpResult::AOR_EMAIL_TOO_LONG;
-  }
-
-  Utf8ToUpperOnlyLatin(username);
-  Utf8ToUpperOnlyLatin(newEmail);
-
-  LoginDatabasePreparedStatement *stmt =
-      LoginDatabase.GetPreparedStatement(LOGIN_UPD_EMAIL);
-
-  stmt->setString(0, newEmail);
-  stmt->setUInt32(1, accountId);
-
-  LoginDatabase.Execute(stmt);
-
-  sScriptMgr->OnEmailChange(accountId);
-  return AccountOpResult::AOR_OK;
-}
-
-AccountOpResult AccountMgr::ChangeRegEmail(uint32 accountId,
-                                           std::string newEmail) {
-  std::string username;
-
-  if (!GetName(accountId, username))
-    return AccountOpResult::AOR_NAME_NOT_EXIST; // account doesn't exist
-
-  if (utf8length(newEmail) > MAX_EMAIL_STR) {
-    sScriptMgr->OnFailedEmailChange(accountId);
-    return AccountOpResult::AOR_EMAIL_TOO_LONG;
-  }
-
-  Utf8ToUpperOnlyLatin(username);
-  Utf8ToUpperOnlyLatin(newEmail);
-
-  LoginDatabasePreparedStatement *stmt =
-      LoginDatabase.GetPreparedStatement(LOGIN_UPD_REG_EMAIL);
-
-  stmt->setString(0, newEmail);
-  stmt->setUInt32(1, accountId);
-
-  LoginDatabase.Execute(stmt);
-
-  sScriptMgr->OnEmailChange(accountId);
-  return AccountOpResult::AOR_OK;
-}
-
-uint32 AccountMgr::GetId(std::string const &username) {
-  LoginDatabasePreparedStatement *stmt =
-      LoginDatabase.GetPreparedStatement(LOGIN_GET_ACCOUNT_ID_BY_USERNAME);
-  stmt->setString(0, username);
-  PreparedQueryResult result = LoginDatabase.Query(stmt);
-
-  return (result) ? (*result)[0].GetUInt32() : 0;
-}
-
-uint32 AccountMgr::GetSecurity(uint32 accountId, int32 realmId) {
-  LoginDatabasePreparedStatement *stmt =
-      LoginDatabase.GetPreparedStatement(LOGIN_GET_GMLEVEL_BY_REALMID);
-  stmt->setUInt32(0, accountId);
-  stmt->setInt32(1, realmId);
-  PreparedQueryResult result = LoginDatabase.Query(stmt);
-
-  return (result) ? (*result)[0].GetUInt8() : uint32(SEC_PLAYER);
-}
-
-QueryCallback
-AccountMgr::GetSecurityAsync(uint32 accountId, int32 realmId,
-                             std::function<void(uint32)> callback) {
-  LoginDatabasePreparedStatement *stmt =
-      LoginDatabase.GetPreparedStatement(LOGIN_GET_GMLEVEL_BY_REALMID);
-  stmt->setUInt32(0, accountId);
-  stmt->setInt32(1, realmId);
-  return LoginDatabase.AsyncQuery(stmt).WithPreparedCallback(
-      [callback = std::move(callback)](PreparedQueryResult result) {
-        callback(result ? uint32((*result)[0].GetUInt8()) : uint32(SEC_PLAYER));
-      });
-}
-
-bool AccountMgr::GetName(uint32 accountId, std::string &name) {
-  LoginDatabasePreparedStatement *stmt =
-      LoginDatabase.GetPreparedStatement(LOGIN_GET_USERNAME_BY_ID);
-  stmt->setUInt32(0, accountId);
-  PreparedQueryResult result = LoginDatabase.Query(stmt);
-
-  if (result) {
-    name = (*result)[0].GetString();
-    return true;
-  }
-
-  return false;
-}
-
-bool AccountMgr::GetEmail(uint32 accountId, std::string &email) {
-  LoginDatabasePreparedStatement *stmt =
-      LoginDatabase.GetPreparedStatement(LOGIN_GET_EMAIL_BY_ID);
-  stmt->setUInt32(0, accountId);
-  PreparedQueryResult result = LoginDatabase.Query(stmt);
-
-  if (result) {
-    email = (*result)[0].GetString();
-    return true;
-  }
-
-  return false;
-}
-
-bool AccountMgr::CheckPassword(uint32 accountId, std::string password) {
-  std::string username;
-
-  if (!GetName(accountId, username))
-    return false;
-
-  Utf8ToUpperOnlyLatin(username);
-  Utf8ToUpperOnlyLatin(password);
-
-  LoginDatabasePreparedStatement *stmt =
-      LoginDatabase.GetPreparedStatement(LOGIN_SEL_CHECK_PASSWORD);
-  stmt->setUInt32(0, accountId);
-  stmt->setString(1, CalculateShaPassHash(username, password));
-  PreparedQueryResult result = LoginDatabase.Query(stmt);
-
-  return (result) ? true : false;
-}
-
-bool AccountMgr::CheckEmail(uint32 accountId, std::string newEmail) {
-  std::string oldEmail;
-
-  // We simply return false for a non-existing email
-  if (!GetEmail(accountId, oldEmail))
-    return false;
-
-  Utf8ToUpperOnlyLatin(oldEmail);
-  Utf8ToUpperOnlyLatin(newEmail);
-
-  if (strcmp(oldEmail.c_str(), newEmail.c_str()) == 0)
-    return true;
-
-  return false;
-}
-
-uint32 AccountMgr::GetCharactersCount(uint32 accountId) {
-  // check character count
-  CharacterDatabasePreparedStatement *stmt =
-      CharacterDatabase.GetPreparedStatement(CHAR_SEL_SUM_CHARS);
-  stmt->setUInt32(0, accountId);
-  PreparedQueryResult result = CharacterDatabase.Query(stmt);
-
-  return (result) ? (*result)[0].GetUInt64() : 0;
-}
-
-std::string AccountMgr::CalculateShaPassHash(std::string const &name,
-                                             std::string const &password) {
-  SHA1Hash sha;
-  sha.Initialize();
-  sha.UpdateData(name);
-  sha.UpdateData(":");
-  sha.UpdateData(password);
-  sha.Finalize();
-
-  return ByteArrayToHexStr(sha.GetDigest(), sha.GetLength());
-}
-
-bool AccountMgr::IsBannedAccount(std::string const &name) {
-  LoginDatabasePreparedStatement *stmt =
-      LoginDatabase.GetPreparedStatement(LOGIN_SEL_ACCOUNT_BANNED_BY_USERNAME);
-  stmt->setString(0, name);
-  PreparedQueryResult result = LoginDatabase.Query(stmt);
-
-  if (!result)
-    return false;
-
-  return true;
-}
-
-bool AccountMgr::IsPlayerAccount(uint32 gmlevel) {
-  return gmlevel == SEC_PLAYER;
-}
-
-bool AccountMgr::IsAdminAccount(uint32 gmlevel) {
-  return gmlevel >= SEC_ADMINISTRATOR && gmlevel <= SEC_CONSOLE;
-}
-
-bool AccountMgr::IsConsoleAccount(uint32 gmlevel) {
-  return gmlevel == SEC_CONSOLE;
-}
-
-void AccountMgr::LoadRBAC() {
-  ClearRBAC();
-
-  LOG_DEBUG("rbac", "AccountMgr::LoadRBAC");
-  uint32 oldMSTime = getMSTime();
-  uint32 count1 = 0;
-  uint32 count2 = 0;
-  uint32 count3 = 0;
-
-  LOG_DEBUG("rbac", "AccountMgr::LoadRBAC: Loading permissions");
-  QueryResult result =
-      LoginDatabase.Query("SELECT id, name FROM rbac_permissions");
-  if (!result) {
-    LOG_INFO("server.loading", ">> Loaded 0 account permission definitions. "
-                                  "DB table `rbac_permissions` is empty.");
-    return;
-  }
-
-  do {
-    Field *field = result->Fetch();
-    uint32 id = field[0].GetUInt32();
-    _permissions[id] = new rbac::RBACPermission(id, field[1].GetString());
-    ++count1;
-  } while (result->NextRow());
-
-  LOG_DEBUG("rbac", "AccountMgr::LoadRBAC: Loading linked permissions");
-  result = LoginDatabase.Query(
-      "SELECT id, linkedId FROM rbac_linked_permissions ORDER BY id ASC");
-  if (!result) {
-    LOG_INFO("server.loading", ">> Loaded 0 linked permissions. DB table "
-                                  "`rbac_linked_permissions` is empty.");
-    return;
-  }
-
-  uint32 permissionId = 0;
-  rbac::RBACPermission *permission = nullptr;
-
-  do {
-    Field *field = result->Fetch();
-    uint32 newId = field[0].GetUInt32();
-    if (permissionId != newId) {
-      permissionId = newId;
-      permission = _permissions[newId];
+    LOG_DEBUG("rbac", "AccountMgr::LoadRBAC: Loading linked permissions");
+    result = LoginDatabase.Query("SELECT id, linkedId FROM rbac_linked_permissions ORDER BY id ASC");
+    if (!result)
+    {
+        LOG_INFO("server.loading", ">> Loaded 0 linked permissions. DB table "
+                                   "`rbac_linked_permissions` is empty.");
+        return;
     }
 
-    uint32 linkedPermissionId = field[1].GetUInt32();
-    if (linkedPermissionId == permissionId) {
-      LOG_ERROR(
-          "sql.sql",
-          "RBAC Permission %u has itself as linked permission. Ignored",
-          permissionId);
-      continue;
-    }
-    permission->AddLinkedPermission(linkedPermissionId);
-    ++count2;
-  } while (result->NextRow());
+    uint32 permissionId = 0;
+    rbac::RBACPermission* permission = nullptr;
 
-  LOG_DEBUG("rbac", "AccountMgr::LoadRBAC: Loading default permissions");
-  result = LoginDatabase.PQuery(
-      "SELECT secId, permissionId FROM rbac_default_permissions WHERE (realmId "
-      "= %u OR realmId = -1) ORDER BY secId ASC",
-      realm.Id.Realm);
-  if (!result) {
+    do
+    {
+        Field* field = result->Fetch();
+        uint32 newId = field[0].GetUInt32();
+        if (permissionId != newId)
+        {
+            permissionId = newId;
+            permission = _permissions[newId];
+        }
+
+        uint32 linkedPermissionId = field[1].GetUInt32();
+        if (linkedPermissionId == permissionId)
+        {
+            LOG_ERROR("sql.sql", "RBAC Permission %u has itself as linked permission. Ignored", permissionId);
+            continue;
+        }
+        permission->AddLinkedPermission(linkedPermissionId);
+        ++count2;
+    } while (result->NextRow());
+
+    LOG_DEBUG("rbac", "AccountMgr::LoadRBAC: Loading default permissions");
+    result = LoginDatabase.PQuery("SELECT secId, permissionId FROM rbac_default_permissions WHERE (realmId "
+                                  "= %u OR realmId = -1) ORDER BY secId ASC",
+        realm.Id.Realm);
+    if (!result)
+    {
+        LOG_INFO("server.loading", ">> Loaded 0 default permission definitions. DB table "
+                                   "`rbac_default_permissions` is empty.");
+        return;
+    }
+
+    uint8 secId = 255;
+    rbac::RBACPermissionContainer* permissions = nullptr;
+    do
+    {
+        Field* field = result->Fetch();
+        uint32 newId = field[0].GetUInt32();
+        if (secId != newId || permissions == nullptr)
+        {
+            secId = newId;
+            permissions = &_defaultPermissions[secId];
+        }
+
+        permissions->insert(field[1].GetUInt32());
+        ++count3;
+    } while (result->NextRow());
+
     LOG_INFO("server.loading",
-                ">> Loaded 0 default permission definitions. DB table "
-                "`rbac_default_permissions` is empty.");
-    return;
-  }
+        ">> Loaded %u permission definitions, %u linked permissions and "
+        "%u default permissions in %u ms",
+        count1, count2, count3, GetMSTimeDiffToNow(oldMSTime));
+}
 
-  uint8 secId = 255;
-  rbac::RBACPermissionContainer *permissions = nullptr;
-  do {
-    Field *field = result->Fetch();
-    uint32 newId = field[0].GetUInt32();
-    if (secId != newId || permissions == nullptr) {
-      secId = newId;
-      permissions = &_defaultPermissions[secId];
+void AccountMgr::UpdateAccountAccess(rbac::RBACData* rbac, uint32 accountId, uint8 securityLevel, int32 realmId)
+{
+
+    if (rbac && securityLevel != rbac->GetSecurityLevel())
+        rbac->SetSecurityLevel(securityLevel);
+
+    LoginDatabaseTransaction trans = LoginDatabase.BeginTransaction();
+    // Delete old security level from DB
+    if (realmId == -1)
+    {
+        LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_DEL_ACCOUNT_ACCESS);
+        stmt->setUInt32(0, accountId);
+        trans->Append(stmt);
+    }
+    else
+    {
+        LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_DEL_ACCOUNT_ACCESS_BY_REALM);
+        stmt->setUInt32(0, accountId);
+        stmt->setUInt32(1, realmId);
+        trans->Append(stmt);
     }
 
-    permissions->insert(field[1].GetUInt32());
-    ++count3;
-  } while (result->NextRow());
+    // Add new security level
+    if (securityLevel)
+    {
+        LoginDatabasePreparedStatement* stmt = LoginDatabase.GetPreparedStatement(LOGIN_INS_ACCOUNT_ACCESS);
+        stmt->setUInt32(0, accountId);
+        stmt->setUInt8(1, securityLevel);
+        stmt->setInt32(2, realmId);
+        trans->Append(stmt);
 
-  LOG_INFO("server.loading",
-              ">> Loaded %u permission definitions, %u linked permissions and "
-              "%u default permissions in %u ms",
-              count1, count2, count3, GetMSTimeDiffToNow(oldMSTime));
+        stmt = LoginDatabase.GetPreparedStatement(LOGIN_INS_RBAC_ACCOUNT_PERMISSION);
+        stmt->setUInt32(0, accountId);
+        stmt->setUInt32(1, accountAccessMap[securityLevel]);
+        stmt->setUInt8(2, 1);
+        stmt->setInt32(3, realmId);
+        trans->Append(stmt);
+    }
+
+    LoginDatabase.CommitTransaction(trans);
 }
 
-void AccountMgr::UpdateAccountAccess(rbac::RBACData *rbac, uint32 accountId,
-                                     uint8 securityLevel, int32 realmId) {
-  if (rbac && securityLevel != rbac->GetSecurityLevel())
-    rbac->SetSecurityLevel(securityLevel);
+rbac::RBACPermission const* AccountMgr::GetRBACPermission(uint32 permissionId) const
+{
+    LOG_TRACE("rbac", "AccountMgr::GetRBACPermission: %u", permissionId);
+    rbac::RBACPermissionsContainer::const_iterator it = _permissions.find(permissionId);
+    if (it != _permissions.end())
+        return it->second;
 
-  LoginDatabaseTransaction trans = LoginDatabase.BeginTransaction();
-  // Delete old security level from DB
-  if (realmId == -1) {
-    LoginDatabasePreparedStatement *stmt =
-        LoginDatabase.GetPreparedStatement(LOGIN_DEL_ACCOUNT_ACCESS);
-    stmt->setUInt32(0, accountId);
-    trans->Append(stmt);
-  } else {
-    LoginDatabasePreparedStatement *stmt =
-        LoginDatabase.GetPreparedStatement(LOGIN_DEL_ACCOUNT_ACCESS_BY_REALM);
-    stmt->setUInt32(0, accountId);
-    stmt->setUInt32(1, realmId);
-    trans->Append(stmt);
-  }
-
-  // Add new security level
-  if (securityLevel) {
-    LoginDatabasePreparedStatement *stmt =
-        LoginDatabase.GetPreparedStatement(LOGIN_INS_ACCOUNT_ACCESS);
-    stmt->setUInt32(0, accountId);
-    stmt->setUInt8(1, securityLevel);
-    stmt->setInt32(2, realmId);
-    trans->Append(stmt);
-  }
-
-  LoginDatabase.CommitTransaction(trans);
+    return nullptr;
 }
 
-rbac::RBACPermission const *
-AccountMgr::GetRBACPermission(uint32 permissionId) const {
-  LOG_TRACE("rbac", "AccountMgr::GetRBACPermission: %u", permissionId);
-  rbac::RBACPermissionsContainer::const_iterator it =
-      _permissions.find(permissionId);
-  if (it != _permissions.end())
-    return it->second;
+bool AccountMgr::HasPermission(uint32 accountId, uint32 permissionId, uint32 realmId)
+{
+    if (!accountId)
+    {
+        LOG_ERROR("rbac", "AccountMgr::HasPermission: Wrong accountId 0");
+        return false;
+    }
 
-  return nullptr;
+    rbac::RBACData rbac(accountId, "", realmId, GetSecurity(accountId, realmId));
+    rbac.LoadFromDB();
+    bool hasPermission = rbac.HasPermission(permissionId);
+
+    LOG_DEBUG("rbac",
+        "AccountMgr::HasPermission [AccountId: %u, PermissionId: %u, "
+        "realmId: %d]: %u",
+        accountId, permissionId, realmId, hasPermission);
+    return hasPermission;
 }
 
-bool AccountMgr::HasPermission(uint32 accountId, uint32 permissionId,
-                               uint32 realmId) {
-  if (!accountId) {
-    LOG_ERROR("rbac", "AccountMgr::HasPermission: Wrong accountId 0");
-    return false;
-  }
+void AccountMgr::ClearRBAC()
+{
+    for (rbac::RBACPermissionsContainer::iterator itr = _permissions.begin(); itr != _permissions.end(); ++itr)
+        delete itr->second;
 
-  rbac::RBACData rbac(accountId, "", realmId, GetSecurity(accountId, realmId));
-  rbac.LoadFromDB();
-  bool hasPermission = rbac.HasPermission(permissionId);
-
-  LOG_DEBUG("rbac",
-               "AccountMgr::HasPermission [AccountId: %u, PermissionId: %u, "
-               "realmId: %d]: %u",
-               accountId, permissionId, realmId, hasPermission);
-  return hasPermission;
+    _permissions.clear();
+    _defaultPermissions.clear();
 }
 
-void AccountMgr::ClearRBAC() {
-  for (rbac::RBACPermissionsContainer::iterator itr = _permissions.begin();
-       itr != _permissions.end(); ++itr)
-    delete itr->second;
-
-  _permissions.clear();
-  _defaultPermissions.clear();
-}
-
-rbac::RBACPermissionContainer const &
-AccountMgr::GetRBACDefaultPermissions(uint8 secLevel) {
-  LOG_TRACE("rbac",
-               "AccountMgr::GetRBACDefaultPermissions: secLevel %u - size: %u",
-               secLevel, uint32(_defaultPermissions[secLevel].size()));
-  return _defaultPermissions[secLevel];
+rbac::RBACPermissionContainer const& AccountMgr::GetRBACDefaultPermissions(uint8 secLevel)
+{
+    LOG_TRACE("rbac", "AccountMgr::GetRBACDefaultPermissions: secLevel %u - size: %u", secLevel, uint32(_defaultPermissions[secLevel].size()));
+    return _defaultPermissions[secLevel];
 }

--- a/src/server/game/Accounts/AccountMgr.h
+++ b/src/server/game/Accounts/AccountMgr.h
@@ -20,85 +20,81 @@
 #define _ACCMGR_H
 
 #include "RBAC.h"
+#include "Common.h"
 
-enum class AccountOpResult : uint8 {
-  AOR_OK,
-  AOR_NAME_TOO_LONG,
-  AOR_PASS_TOO_LONG,
-  AOR_EMAIL_TOO_LONG,
-  AOR_NAME_ALREADY_EXIST,
-  AOR_NAME_NOT_EXIST,
-  AOR_DB_INTERNAL_ERROR,
-  AOR_ACCOUNT_BAD_LINK
+enum class AccountOpResult : uint8
+{
+    AOR_OK,
+    AOR_NAME_TOO_LONG,
+    AOR_PASS_TOO_LONG,
+    AOR_EMAIL_TOO_LONG,
+    AOR_NAME_ALREADY_EXIST,
+    AOR_NAME_NOT_EXIST,
+    AOR_DB_INTERNAL_ERROR,
+    AOR_ACCOUNT_BAD_LINK
 };
 
-enum PasswordChangeSecurity { PW_NONE, PW_EMAIL, PW_RBAC };
+enum PasswordChangeSecurity
+{
+    PW_NONE,
+    PW_EMAIL,
+    PW_RBAC
+};
 
 #define MAX_PASS_STR 16
 #define MAX_ACCOUNT_STR 16
 #define MAX_EMAIL_STR 64
 
-namespace rbac {
-typedef std::map<uint32, rbac::RBACPermission *> RBACPermissionsContainer;
-typedef std::map<uint8, rbac::RBACPermissionContainer>
-    RBACDefaultPermissionsContainer;
+namespace rbac
+{
+    typedef std::map<uint32, rbac::RBACPermission*> RBACPermissionsContainer;
+    typedef std::map<uint8, rbac::RBACPermissionContainer> RBACDefaultPermissionsContainer;
 } // namespace rbac
 
-class FC_GAME_API AccountMgr {
-private:
-  AccountMgr();
-  ~AccountMgr();
+class FC_GAME_API AccountMgr
+{
+  private:
+    AccountMgr();
+    ~AccountMgr();
 
-public:
-  static AccountMgr *instance();
+  public:
+    static AccountMgr* instance();
 
-  AccountOpResult CreateAccount(std::string username, std::string password,
-                                std::string email = "");
-  static AccountOpResult DeleteAccount(uint32 accountId);
-  static AccountOpResult ChangeUsername(uint32 accountId,
-                                        std::string newUsername,
-                                        std::string newPassword);
-  static AccountOpResult ChangePassword(uint32 accountId,
-                                        std::string newPassword);
-  static AccountOpResult ChangeEmail(uint32 accountId, std::string newEmail);
-  static AccountOpResult ChangeRegEmail(uint32 accountId, std::string newEmail);
-  static bool CheckPassword(uint32 accountId, std::string password);
-  static bool CheckEmail(uint32 accountId, std::string newEmail);
+    AccountOpResult CreateAccount(std::string username, std::string password, std::string email = "");
+    static AccountOpResult DeleteAccount(uint32 accountId);
+    static AccountOpResult ChangeUsername(uint32 accountId, std::string newUsername, std::string newPassword);
+    static AccountOpResult ChangePassword(uint32 accountId, std::string newPassword);
+    static AccountOpResult ChangeEmail(uint32 accountId, std::string newEmail);
+    static AccountOpResult ChangeRegEmail(uint32 accountId, std::string newEmail);
+    static bool CheckPassword(uint32 accountId, std::string password);
+    static bool CheckEmail(uint32 accountId, std::string newEmail);
 
-  static uint32 GetId(std::string const &username);
-  static uint32 GetSecurity(uint32 accountId, int32 realmId);
-  [[nodiscard]] static QueryCallback
-  GetSecurityAsync(uint32 accountId, int32 realmId,
-                   std::function<void(uint32)> callback);
-  static bool GetName(uint32 accountId, std::string &name);
-  static bool GetEmail(uint32 accountId, std::string &email);
-  static uint32 GetCharactersCount(uint32 accountId);
+    static uint32 GetId(std::string const& username);
+    static uint32 GetSecurity(uint32 accountId, int32 realmId);
+    [[nodiscard]] static QueryCallback GetSecurityAsync(uint32 accountId, int32 realmId, std::function<void(uint32)> callback);
+    static bool GetName(uint32 accountId, std::string& name);
+    static bool GetEmail(uint32 accountId, std::string& email);
+    static uint32 GetCharactersCount(uint32 accountId);
 
-  static std::string CalculateShaPassHash(std::string const &name,
-                                          std::string const &password);
-  static bool IsBannedAccount(std::string const &name);
-  static bool IsPlayerAccount(uint32 gmlevel);
-  static bool IsAdminAccount(uint32 gmlevel);
-  static bool IsConsoleAccount(uint32 gmlevel);
-  static bool HasPermission(uint32 accountId, uint32 permission,
-                            uint32 realmId);
+    static std::string CalculateShaPassHash(std::string const& name, std::string const& password);
+    static bool IsBannedAccount(std::string const& name);
+    static bool IsPlayerAccount(uint32 gmlevel);
+    static bool IsAdminAccount(uint32 gmlevel);
+    static bool IsConsoleAccount(uint32 gmlevel);
+    static bool HasPermission(uint32 accountId, uint32 permission, uint32 realmId);
 
-  void UpdateAccountAccess(rbac::RBACData *rbac, uint32 accountId,
-                           uint8 securityLevel, int32 realmId);
+    void UpdateAccountAccess(rbac::RBACData* rbac, uint32 accountId, uint8 securityLevel, int32 realmId);
 
-  void LoadRBAC();
-  rbac::RBACPermission const *GetRBACPermission(uint32 permission) const;
+    void LoadRBAC();
+    rbac::RBACPermission const* GetRBACPermission(uint32 permission) const;
 
-  rbac::RBACPermissionsContainer const &GetRBACPermissionList() const {
-    return _permissions;
-  }
-  rbac::RBACPermissionContainer const &
-  GetRBACDefaultPermissions(uint8 secLevel);
+    rbac::RBACPermissionsContainer const& GetRBACPermissionList() const { return _permissions; }
+    rbac::RBACPermissionContainer const& GetRBACDefaultPermissions(uint8 secLevel);
 
-private:
-  void ClearRBAC();
-  rbac::RBACPermissionsContainer _permissions;
-  rbac::RBACDefaultPermissionsContainer _defaultPermissions;
+  private:
+    void ClearRBAC();
+    rbac::RBACPermissionsContainer _permissions;
+    rbac::RBACDefaultPermissionsContainer _defaultPermissions;
 };
 
 #define sAccountMgr AccountMgr::instance()


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
### Changes proposed

- Add RBAC Permissions when you set a gmlevel for account the idea is to start a migration process over the old table account_access, and migrate to rbac_account_permissions.


### Tests performed
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- build test
- in game test

### How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. download the branch
2. build it and start worldserver
3. use the command `account set gmlevel`
4. after set gm level,  check the `rbac_account_permissions` table and verify that your gm level is added to it as a permission.

---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
