### PR TITLE
Implement (core): Despawn on Summoner Death Flag

### DIFF
--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -299,17 +299,6 @@ bool CreatureAI::_EnterEvadeMode(EvadeReason /*why*/)
         return false;
     }
 
-    if (TempSummon* summon = me->ToTempSummon())
-    {
-        if (SummonPropertiesEntry const* properties = summon->m_Properties)
-        { // Allied summons, pet summons join a formation unless the following exceptions are being met.
-            if ((properties->Flags & SUMMON_PROP_FLAG_DESPAWN_ON_SUMMONER_DEATH) || ((me->IsGuardian() || me->IsPet()) && !me->GetOwner()->IsAlive()))
-            {
-                me->DespawnOrUnsummon();
-                return true;
-            }
-        }
-    }
 
     me->RemoveAurasOnEvade();
 
@@ -324,6 +313,17 @@ bool CreatureAI::_EnterEvadeMode(EvadeReason /*why*/)
     me->SetTarget(ObjectGuid::Empty);
     EngagementOver();
 
+    if (TempSummon* summon = me->ToTempSummon())
+    {
+        if (SummonPropertiesEntry const* properties = summon->m_Properties)
+        { // Allied summons, pet summons join a formation unless the following exceptions are being met.
+            if ((properties->Flags & SUMMON_PROP_FLAG_DESPAWN_ON_SUMMONER_DEATH) || ((me->IsGuardian() || me->IsPet()) && !me->GetOwner()->IsAlive()))
+            {
+                me->DespawnOrUnsummon();
+                return true;
+            }
+        }
+    }
     return true;
 }
 

--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -303,7 +303,7 @@ bool CreatureAI::_EnterEvadeMode(EvadeReason /*why*/)
     {
         if (SummonPropertiesEntry const* properties = summon->m_Properties)
         { // Allied summons, pet summons join a formation unless the following exceptions are being met.
-            if (properties->Flags & SUMMON_PROP_FLAG_DESPAWN_ON_SUMMONER_DEATH)
+            if (properties->Flags & SUMMON_PROP_FLAG_DESPAWN_ON_SUMMONER_DEATH || (me->IsGuardian() || me->IsPet()) && !me->GetOwner()->IsAlive())
             {
                 me->DespawnOrUnsummon();
                 return true;

--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -185,6 +185,7 @@ static bool ShouldFollowOnSpawn(SummonPropertiesEntry const* properties)
         return false;
     }
 }
+
 void CreatureAI::JustAppeared()
 {
     if (!IsEngaged())
@@ -296,6 +297,18 @@ bool CreatureAI::_EnterEvadeMode(EvadeReason /*why*/)
     {
         EngagementOver();
         return false;
+    }
+
+    if (TempSummon* summon = me->ToTempSummon())
+    {
+        if (SummonPropertiesEntry const* properties = summon->m_Properties)
+        { // Allied summons, pet summons join a formation unless the following exceptions are being met.
+            if (properties->Flags & SUMMON_PROP_FLAG_DESPAWN_ON_SUMMONER_DEATH)
+            {
+                me->DespawnOrUnsummon();
+                return true;
+            }
+        }
     }
 
     me->RemoveAurasOnEvade();

--- a/src/server/game/AI/CreatureAI.cpp
+++ b/src/server/game/AI/CreatureAI.cpp
@@ -303,7 +303,7 @@ bool CreatureAI::_EnterEvadeMode(EvadeReason /*why*/)
     {
         if (SummonPropertiesEntry const* properties = summon->m_Properties)
         { // Allied summons, pet summons join a formation unless the following exceptions are being met.
-            if (properties->Flags & SUMMON_PROP_FLAG_DESPAWN_ON_SUMMONER_DEATH || (me->IsGuardian() || me->IsPet()) && !me->GetOwner()->IsAlive())
+            if ((properties->Flags & SUMMON_PROP_FLAG_DESPAWN_ON_SUMMONER_DEATH) || ((me->IsGuardian() || me->IsPet()) && !me->GetOwner()->IsAlive()))
             {
                 me->DespawnOrUnsummon();
                 return true;

--- a/src/server/game/DataStores/DBCEnums.h
+++ b/src/server/game/DataStores/DBCEnums.h
@@ -666,7 +666,7 @@ enum SummonPropFlags
     SUMMON_PROP_FLAG_UNK1            = 0x00000001,          // 75 spells in 3.0.3, something unfriendly
     SUMMON_PROP_FLAG_UNK2            = 0x00000002,          // 616 spells in 3.0.3, something friendly
     SUMMON_PROP_FLAG_UNK3            = 0x00000004,          // 22 spells in 3.0.3, no idea...
-    SUMMON_PROP_FLAG_UNK4            = 0x00000008,          // 49 spells in 3.0.3, some mounts
+    SUMMON_PROP_FLAG_DESPAWN_ON_SUMMONER_DEATH            = 0x00000008,          // 49 spells in 3.0.3, some mounts, Despawns on Summoner Death
     SUMMON_PROP_FLAG_PERSONAL_SPAWN  = 0x00000010,          // Only Visible to Summoner
     SUMMON_PROP_FLAG_UNK6            = 0x00000020,          // 0 spells in 3.3.5, unused
     SUMMON_PROP_FLAG_UNK7            = 0x00000040,          // 12 spells in 3.0.3, no idea

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6386,6 +6386,8 @@ Unit* Unit::GetFirstControlled() const
     return unit;
 }
 
+// RemoveAllControlled gets called twice - in Unit::setDeathState() & void Unit::RemoveFromWorld()
+// It removes charming effects, controlled vehicles and unsummons minions.
 void Unit::RemoveAllControlled()
 {
     // possessed pet and vehicle
@@ -6394,23 +6396,37 @@ void Unit::RemoveAllControlled()
 
     while (!m_Controlled.empty())
     {
+        bool controlledKeepsFighting = false;
+
         Unit* target = *m_Controlled.begin();
         m_Controlled.erase(m_Controlled.begin());
         if (target->GetCharmerGUID() == GetGUID())
             target->RemoveCharmAuras();
+        // A pet/guardian should continue combat. Since we despawned every other summon type in UnsummonAllTotems(), we can waive on a additional type check and continue with IsSummon().
         else if (target->GetOwnerOrCreatorGUID() == GetGUID() && target->IsSummon())
-            target->ToTempSummon()->UnSummon();
+        {
+            if (!target->IsInCombat())
+                target->ToTempSummon()->UnSummon();
+            else
+                // we set this for edge case checks
+                controlledKeepsFighting = true;
+        }
         else
             LOG_ERROR("entities.unit", "Unit %u is trying to release unit %u which is neither charmed nor owned by it", GetEntry(), target->GetEntry());
+        
+        // checking for edge cases
+        if (!controlledKeepsFighting)
+        {
+            if (GetPetGUID())
+                LOG_FATAL("entities.unit", "Unit %u is not able to release its pet %s", GetEntry(), GetPetGUID().ToString().c_str());
+            if (GetMinionGUID())
+                LOG_FATAL("entities.unit", "Unit %u is not able to release its minion %s", GetEntry(), GetMinionGUID().ToString().c_str());
+            if (GetCharmedGUID())
+                LOG_FATAL("entities.unit", "Unit %u is not able to release its charm %s", GetEntry(), GetCharmedGUID().ToString().c_str());
+            if (!IsPet())                                              // pets don't use the flag for this
+                RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PET_IN_COMBAT); // m_controlled is now empty, so we know none of our minions are in combat
+        }
     }
-    if (GetPetGUID())
-        LOG_FATAL("entities.unit", "Unit %u is not able to release its pet %s", GetEntry(), GetPetGUID().ToString().c_str());
-    if (GetMinionGUID())
-        LOG_FATAL("entities.unit", "Unit %u is not able to release its minion %s", GetEntry(), GetMinionGUID().ToString().c_str());
-    if (GetCharmedGUID())
-        LOG_FATAL("entities.unit", "Unit %u is not able to release its charm %s", GetEntry(), GetCharmedGUID().ToString().c_str());
-    if (!IsPet())                                              // pets don't use the flag for this
-        RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PET_IN_COMBAT); // m_controlled is now empty, so we know none of our minions are in combat
 }
 
 bool Unit::isPossessedByPlayer() const { return HasUnitState(UNIT_STATE_POSSESSED) && GetCharmerGUID().IsPlayer(); }
@@ -6515,6 +6531,8 @@ void Unit::RemoveCharmAuras()
     RemoveAurasByType(SPELL_AURA_AOE_CHARM);
 }
 
+// UnsummonAllTotems gets called twice - in Unit::setDeathState() & void Unit::RemoveFromWorld()
+// It iterates through all summon slots and despawns the summons
 void Unit::UnsummonAllTotems()
 {
     for (uint8 i = 0; i < MAX_SUMMON_SLOT; ++i)
@@ -6523,8 +6541,15 @@ void Unit::UnsummonAllTotems()
             continue;
 
         if (Creature* OldTotem = GetMap()->GetCreature(m_SummonSlot[i]))
+        {
             if (OldTotem->IsSummon())
-                OldTotem->ToTempSummon()->UnSummon();
+            // We want to keep guardians and pets alive for now. A InCombat check is not needed here, we do this
+            // in void Unit::RemoveAllControlled()
+            {
+                if (!OldTotem->IsGuardian() && !OldTotem->IsPet())
+                    OldTotem->ToTempSummon()->UnSummon();
+            }
+        }
     }
 }
 

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6413,7 +6413,7 @@ void Unit::RemoveAllControlled()
         }
         else
             LOG_ERROR("entities.unit", "Unit %u is trying to release unit %u which is neither charmed nor owned by it", GetEntry(), target->GetEntry());
-        
+
         // checking for edge cases
         if (!controlledKeepsFighting)
         {

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6388,7 +6388,7 @@ Unit* Unit::GetFirstControlled() const
 
 // RemoveAllControlled gets called twice - in Unit::setDeathState() & void Unit::RemoveFromWorld()
 // It removes charming effects, controlled vehicles and unsummons minions.
-void Unit::RemoveAllControlled()
+void Unit::RemoveAllControlled(bool onDeath /*= false*/)
 {
     // possessed pet and vehicle
     if (GetTypeId() == TYPEID_PLAYER)
@@ -6405,6 +6405,10 @@ void Unit::RemoveAllControlled()
         // A pet/guardian should continue combat. Since we despawned every other summon type in UnsummonAllTotems(), we can waive on a additional type check and continue with IsSummon().
         else if (target->GetOwnerOrCreatorGUID() == GetGUID() && target->IsSummon())
         {
+            if (!(onDeath && !IsPlayer() && target->IsGuardian()))
+            {
+                target->ToTempSummon()->UnSummon();
+            }
             if (!target->IsInCombat())
                 target->ToTempSummon()->UnSummon();
             else

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1302,7 +1302,7 @@ class FC_GAME_API Unit : public WorldObject
 
     ControlList m_Controlled;
     Unit* GetFirstControlled() const;
-    void RemoveAllControlled();
+    void RemoveAllControlled(bool onDeath = false);
 
     bool IsCharmed() const { return !GetCharmerGUID().IsEmpty(); }
     bool IsCharming() const { return !GetCharmedGUID().IsEmpty(); }


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
Pets\Guardians\Totems\Temp Summons are not suppose to despawn when their summoner is killed unless they have the SUMMON_PROP_FLAG_DESPAWN_ON_SUMMONER_DEATH flag.
This deals with the SUMMON_PROP_FLAG_DESPAWN_ON_SUMMONER_DEATH Flag not being implemented or scripted.
We script and label this flag to ensure it is works in core.

### Changes proposed
![image](https://github.com/FirelandsProject/firelands-cata/assets/16887899/ab8c9634-ad48-4ce8-b539-a048cee1c40c)

- label SUMMON_PROP_FLAG_DESPAWN_ON_SUMMONER_DEATH summon properly
- script SUMMON_PROP_FLAG_DESPAWN_ON_SUMMONER_DEATH flag

### Issues addressed
<!-- If your fix has a relating issue, link it below -->

- Closes None

### SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

- 
- 

### Tests performed
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

- type in .cheat god
- .go c 303878
- kill the razorman hunter, observe its pet is still present and did not auto despawn.

---

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
