### PR TITLE
Core/Spells: Fix periodic rolling adding bonuses twice

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -14300,21 +14300,6 @@ void Unit::OutDebugInfo() const
         LOG_DEBUG("entities.unit", "On vehicle %u.", GetVehicleBase()->GetEntry());
 }
 
-uint32 Unit::GetRemainingPeriodicAmount(ObjectGuid caster, uint32 spellId, AuraType auraType, uint8 effectIndex) const
-{
-    uint32 amount = 0;
-    AuraEffectList const& periodicAuras = GetAuraEffectsByType(auraType);
-    for (AuraEffectList::const_iterator i = periodicAuras.begin(); i != periodicAuras.end(); ++i)
-    {
-        if ((*i)->GetCasterGUID() != caster || (*i)->GetId() != spellId || (*i)->GetEffIndex() != effectIndex || !(*i)->GetTotalTicks())
-            continue;
-        amount += uint32(((*i)->GetAmount() * std::max<int32>((*i)->GetTotalTicks() - int32((*i)->GetTickNumber()), 0)) / (*i)->GetTotalTicks());
-        break;
-    }
-
-    return amount;
-}
-
 void Unit::SendClearTarget()
 {
     WorldPackets::Combat::BreakTarget packet;

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -1664,8 +1664,6 @@ class FC_GAME_API Unit : public WorldObject
     uint32 GetCastingTimeForBonus(SpellInfo const* spellProto, DamageEffectType damagetype, uint32 CastingTime) const;
     float CalculateDefaultCoefficient(SpellInfo const* spellInfo, DamageEffectType damagetype) const;
 
-    uint32 GetRemainingPeriodicAmount(ObjectGuid caster, uint32 spellId, AuraType auraType, uint8 effectIndex = 0) const;
-
     void ApplySpellImmune(uint32 spellId, uint32 op, uint32 type, bool apply);
     virtual bool IsImmunedToSpell(SpellInfo const* spellInfo, Unit* caster, Optional<uint8> effectMask = {}) const; // redefined in Creature
     uint32 GetSchoolImmunityMask() const;

--- a/src/server/game/Spells/Auras/SpellAuraDefines.h
+++ b/src/server/game/Spells/Auras/SpellAuraDefines.h
@@ -525,11 +525,7 @@ struct FC_GAME_API AuraCreateInfo
         CastItem = item;
         return *this;
     }
-    AuraCreateInfo& SetPeriodicReset(bool reset)
-    {
-        ResetPeriodicTimer = reset;
-        return *this;
-    }
+
     AuraCreateInfo& SetOwnerEffectMask(uint8 effMask)
     {
         _targetEffectMask = effMask;
@@ -544,7 +540,6 @@ struct FC_GAME_API AuraCreateInfo
     int32 const* BaseAmount = nullptr;
     Item* CastItem = nullptr;
     bool* IsRefresh = nullptr;
-    bool ResetPeriodicTimer = true;
 
   private:
     SpellInfo const* _spellInfo = nullptr;

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -451,7 +451,10 @@ AuraEffect::AuraEffect(Aura* base, uint8 effIndex, int32 const* baseAmount, Unit
     CalculateSpellMod();
 }
 
-AuraEffect::~AuraEffect() { delete m_spellmod; }
+AuraEffect::~AuraEffect()
+{
+    delete m_spellmod;
+}
 
 template <typename Container> void AuraEffect::GetTargetList(Container& targetContainer) const
 {

--- a/src/server/game/Spells/Auras/SpellAuraEffects.cpp
+++ b/src/server/game/Spells/Auras/SpellAuraEffects.cpp
@@ -50,6 +50,7 @@
 #include "WeatherMgr.h"
 #include "WorldPacket.h"
 #include <G3D/g3dmath.h>
+#include <numeric>
 
 class Aura;
 //
@@ -450,10 +451,7 @@ AuraEffect::AuraEffect(Aura* base, uint8 effIndex, int32 const* baseAmount, Unit
     CalculateSpellMod();
 }
 
-AuraEffect::~AuraEffect()
-{
-    delete m_spellmod;
-}
+AuraEffect::~AuraEffect() { delete m_spellmod; }
 
 template <typename Container> void AuraEffect::GetTargetList(Container& targetContainer) const
 {
@@ -614,7 +612,7 @@ int32 AuraEffect::CalculateAmount(Unit* caster)
     return amount;
 }
 
-void AuraEffect::CalculatePeriodic(Unit* caster, bool resetPeriodicTimer /*= true*/, bool load /*= false*/)
+void AuraEffect::CalculatePeriodic(Unit* caster, bool resetPeriodicTimer, bool load)
 {
     // prepare periodics
     switch (GetAuraType())
@@ -1477,7 +1475,7 @@ void AuraEffect::HandleModInvisibilityDetect(AuraApplication const* aurApp, uint
 
     // call functions which may have additional effects after chainging state of unit
     if (target->IsInWorld())
-    target->UpdateObjectVisibility();
+        target->UpdateObjectVisibility();
 }
 
 void AuraEffect::HandleModInvisibility(AuraApplication const* aurApp, uint8 mode, bool apply) const
@@ -1541,7 +1539,7 @@ void AuraEffect::HandleModInvisibility(AuraApplication const* aurApp, uint8 mode
         target->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags::StealthOrInvis);
     }
     if (target->IsInWorld())
-    target->UpdateObjectVisibility();
+        target->UpdateObjectVisibility();
 }
 
 void AuraEffect::HandleModStealthDetect(AuraApplication const* aurApp, uint8 mode, bool apply) const
@@ -1567,7 +1565,7 @@ void AuraEffect::HandleModStealthDetect(AuraApplication const* aurApp, uint8 mod
 
     // call functions which may have additional effects after chainging state of unit
     if (target->IsInWorld())
-    target->UpdateObjectVisibility();
+        target->UpdateObjectVisibility();
 }
 
 void AuraEffect::HandleModStealth(AuraApplication const* aurApp, uint8 mode, bool apply) const
@@ -1609,7 +1607,7 @@ void AuraEffect::HandleModStealth(AuraApplication const* aurApp, uint8 mode, boo
     }
 
     if (target->IsInWorld())
-    target->UpdateObjectVisibility();
+        target->UpdateObjectVisibility();
 }
 
 void AuraEffect::HandleModStealthLevel(AuraApplication const* aurApp, uint8 mode, bool apply) const
@@ -1627,7 +1625,7 @@ void AuraEffect::HandleModStealthLevel(AuraApplication const* aurApp, uint8 mode
 
     // call functions which may have additional effects after chainging state of unit
     if (target->IsInWorld())
-    target->UpdateObjectVisibility();
+        target->UpdateObjectVisibility();
 }
 
 void AuraEffect::HandleDetectAmore(AuraApplication const* aurApp, uint8 mode, bool apply) const
@@ -2639,7 +2637,7 @@ void AuraEffect::HandleAuraModStalked(AuraApplication const* aurApp, uint8 mode,
 
     // call functions which may have additional effects after chainging state of unit
     if (target->IsInWorld())
-    target->UpdateObjectVisibility();
+        target->UpdateObjectVisibility();
 }
 
 void AuraEffect::HandleAuraUntrackable(AuraApplication const* aurApp, uint8 mode, bool apply) const
@@ -3138,10 +3136,7 @@ void AuraEffect::HandleAuraModIncreaseSpeed(AuraApplication const* aurApp, uint8
     target->UpdateSpeed(MOVE_RUN);
 }
 
-void AuraEffect::HandleAuraModIncreaseMountedSpeed(AuraApplication const* aurApp, uint8 mode, bool apply) const
-{
-    HandleAuraModIncreaseSpeed(aurApp, mode, apply);
-}
+void AuraEffect::HandleAuraModIncreaseMountedSpeed(AuraApplication const* aurApp, uint8 mode, bool apply) const { HandleAuraModIncreaseSpeed(aurApp, mode, apply); }
 
 void AuraEffect::HandleAuraModIncreaseFlightSpeed(AuraApplication const* aurApp, uint8 mode, bool apply) const
 {
@@ -3749,10 +3744,7 @@ void AuraEffect::HandleModPowerRegen(AuraApplication const* aurApp, uint8 mode, 
     aurApp->GetTarget()->UpdatePowerRegeneration(Powers(GetMiscValue()));
 }
 
-void AuraEffect::HandleModPowerRegenPCT(AuraApplication const* aurApp, uint8 mode, bool apply) const
-{
-    HandleModPowerRegen(aurApp, mode, apply);
-}
+void AuraEffect::HandleModPowerRegenPCT(AuraApplication const* aurApp, uint8 mode, bool apply) const { HandleModPowerRegen(aurApp, mode, apply); }
 
 void AuraEffect::HandleModHealingPercent(AuraApplication const* aurApp, uint8 mode, bool /*apply*/) const
 {
@@ -3961,10 +3953,7 @@ void AuraEffect::HandleAuraModBlockPercent(AuraApplication const* aurApp, uint8 
     target->ToPlayer()->UpdateBlockPercentage();
 }
 
-void AuraEffect::HandleAuraModRegenInterrupt(AuraApplication const* aurApp, uint8 mode, bool apply) const
-{
-    HandleModManaRegen(aurApp, mode, apply);
-}
+void AuraEffect::HandleAuraModRegenInterrupt(AuraApplication const* aurApp, uint8 mode, bool apply) const { HandleModManaRegen(aurApp, mode, apply); }
 
 void AuraEffect::HandleAuraModWeaponCritPercent(AuraApplication const* aurApp, uint8 mode, bool /*apply*/) const
 {
@@ -5243,7 +5232,7 @@ void AuraEffect::HandleAuraModFakeInebriation(AuraApplication const* aurApp, uin
 
     // call functions which may have additional effects after chainging state of unit
     if (target->IsInWorld())
-    target->UpdateObjectVisibility();
+        target->UpdateObjectVisibility();
 }
 
 void AuraEffect::HandleAuraOverrideSpells(AuraApplication const* aurApp, uint8 mode, bool apply) const
@@ -5986,7 +5975,7 @@ void AuraEffect::HandlePeriodicHealthLeechAuraTick(Unit* target, Unit* caster) c
     // SendSpellNonMeleeDamageLog expects non-absorbed/non-resisted damage
     if (caster)
 
-    caster->SendSpellNonMeleeDamageLog(target, GetId(), damage, GetSpellInfo()->GetSchoolMask(), absorb, resist, false, 0, crit);
+        caster->SendSpellNonMeleeDamageLog(target, GetId(), damage, GetSpellInfo()->GetSchoolMask(), absorb, resist, false, 0, crit);
     damage = damageInfo.GetDamage();
 
     // Set trigger flag

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -405,14 +405,19 @@ void SpellCastTargets::ModSrc(Position const& pos)
     m_src.Relocate(pos);
 }
 
-void SpellCastTargets::RemoveSrc() { m_targetMask &= ~(TARGET_FLAG_SOURCE_LOCATION); }
+void SpellCastTargets::RemoveSrc() {
+    m_targetMask &= ~(TARGET_FLAG_SOURCE_LOCATION);
+}
 
 SpellDestination const* SpellCastTargets::GetDst() const
 {
     return &m_dst;
 }
 
-WorldLocation const* SpellCastTargets::GetDstPos() const { return &m_dst._position; }
+WorldLocation const* SpellCastTargets::GetDstPos() const
+{
+    return &m_dst._position;
+}
 
 void SpellCastTargets::SetDst(float x, float y, float z, float orientation, uint32 mapId)
 {

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -114,9 +114,7 @@ void SpellDestination::RelocateOffset(Position const& offset)
     _position.RelocateOffset(offset);
 }
 
-SpellCastTargets::SpellCastTargets() : m_targetMask(0), m_objectTarget(nullptr), m_itemTarget(nullptr), m_itemTargetEntry(0), m_elevation(0.f), m_speed(0.f)
-{
-}
+SpellCastTargets::SpellCastTargets() : m_targetMask(0), m_objectTarget(nullptr), m_itemTarget(nullptr), m_itemTargetEntry(0), m_elevation(0.f), m_speed(0.f) {}
 
 SpellCastTargets::SpellCastTargets(Unit* caster, WorldPackets::Spells::SpellCastRequest const& spellCastRequest)
     : m_targetMask(spellCastRequest.Target.Flags), m_objectTarget(nullptr), m_itemTarget(nullptr), m_itemTargetEntry(0), m_elevation(0.0f), m_speed(0.0f)
@@ -160,9 +158,7 @@ SpellCastTargets::SpellCastTargets(Unit* caster, WorldPackets::Spells::SpellCast
     Update(caster);
 }
 
-SpellCastTargets::~SpellCastTargets()
-{
-}
+SpellCastTargets::~SpellCastTargets() {}
 
 void SpellCastTargets::Read(ByteBuffer& data, Unit* caster)
 {
@@ -341,15 +337,9 @@ Corpse* SpellCastTargets::GetCorpseTarget() const
     return nullptr;
 }
 
-WorldObject* SpellCastTargets::GetObjectTarget() const
-{
-    return m_objectTarget;
-}
+WorldObject* SpellCastTargets::GetObjectTarget() const { return m_objectTarget; }
 
-ObjectGuid SpellCastTargets::GetObjectTargetGUID() const
-{
-    return m_objectTargetGUID;
-}
+ObjectGuid SpellCastTargets::GetObjectTargetGUID() const { return m_objectTargetGUID; }
 
 void SpellCastTargets::RemoveObjectTarget()
 {
@@ -387,15 +377,9 @@ void SpellCastTargets::UpdateTradeSlotItem()
     }
 }
 
-SpellDestination const* SpellCastTargets::GetSrc() const
-{
-    return &m_src;
-}
+SpellDestination const* SpellCastTargets::GetSrc() const { return &m_src; }
 
-Position const* SpellCastTargets::GetSrcPos() const
-{
-    return &m_src._position;
-}
+Position const* SpellCastTargets::GetSrcPos() const { return &m_src._position; }
 
 void SpellCastTargets::SetSrc(float x, float y, float z)
 {
@@ -421,20 +405,11 @@ void SpellCastTargets::ModSrc(Position const& pos)
     m_src.Relocate(pos);
 }
 
-void SpellCastTargets::RemoveSrc()
-{
-    m_targetMask &= ~(TARGET_FLAG_SOURCE_LOCATION);
-}
+void SpellCastTargets::RemoveSrc() { m_targetMask &= ~(TARGET_FLAG_SOURCE_LOCATION); }
 
-SpellDestination const* SpellCastTargets::GetDst() const
-{
-    return &m_dst;
-}
+SpellDestination const* SpellCastTargets::GetDst() const { return &m_dst; }
 
-WorldLocation const* SpellCastTargets::GetDstPos() const
-{
-    return &m_dst._position;
-}
+WorldLocation const* SpellCastTargets::GetDstPos() const { return &m_dst._position; }
 
 void SpellCastTargets::SetDst(float x, float y, float z, float orientation, uint32 mapId)
 {
@@ -478,20 +453,11 @@ void SpellCastTargets::ModDst(SpellDestination const& spellDest)
     m_dst = spellDest;
 }
 
-void SpellCastTargets::RemoveDst()
-{
-    m_targetMask &= ~(TARGET_FLAG_DEST_LOCATION);
-}
+void SpellCastTargets::RemoveDst() { m_targetMask &= ~(TARGET_FLAG_DEST_LOCATION); }
 
-bool SpellCastTargets::HasSrc() const
-{
-    return (GetTargetMask() & TARGET_FLAG_SOURCE_LOCATION) != 0;
-}
+bool SpellCastTargets::HasSrc() const { return (GetTargetMask() & TARGET_FLAG_SOURCE_LOCATION) != 0; }
 
-bool SpellCastTargets::HasDst() const
-{
-    return (GetTargetMask() & TARGET_FLAG_DEST_LOCATION) != 0;
-}
+bool SpellCastTargets::HasDst() const { return (GetTargetMask() & TARGET_FLAG_DEST_LOCATION) != 0; }
 
 void SpellCastTargets::Update(Unit* caster)
 {
@@ -576,10 +542,7 @@ class FC_GAME_API SpellEvent : public BasicEvent
     bool Execute(uint64 e_time, uint32 p_time) override;
     void Abort(uint64 e_time) override;
     bool IsDeletable() const override;
-    Spell const* GetSpell() const
-    {
-        return m_Spell;
-    }
+    Spell const* GetSpell() const { return m_Spell; }
 
   protected:
     Spell* m_Spell;
@@ -879,18 +842,20 @@ void Spell::SelectSpellTargets()
         else if (m_auraScaleMask)
         {
             bool checkLvl = !m_UniqueTargetInfo.empty();
-            m_UniqueTargetInfo.erase(std::remove_if(std::begin(m_UniqueTargetInfo), std::end(m_UniqueTargetInfo), [&](TargetInfo const& targetInfo) -> bool
-            {
-                // remove targets which did not pass min level check
-                if (m_auraScaleMask && targetInfo.EffectMask == m_auraScaleMask)
-                {
-                    // Do not check for selfcast
-                    if (!targetInfo.ScaleAura && targetInfo.TargetGUID != m_caster->GetGUID())
-                        return true;
-                }
+            m_UniqueTargetInfo.erase(std::remove_if(std::begin(m_UniqueTargetInfo), std::end(m_UniqueTargetInfo),
+                                         [&](TargetInfo const& targetInfo) -> bool
+                                         {
+                                             // remove targets which did not pass min level check
+                                             if (m_auraScaleMask && targetInfo.EffectMask == m_auraScaleMask)
+                                             {
+                                                 // Do not check for selfcast
+                                                 if (!targetInfo.ScaleAura && targetInfo.TargetGUID != m_caster->GetGUID())
+                                                     return true;
+                                             }
 
-                return false;
-            }), std::end(m_UniqueTargetInfo));
+                                             return false;
+                                         }),
+                std::end(m_UniqueTargetInfo));
 
             if (checkLvl && m_UniqueTargetInfo.empty())
             {
@@ -2166,9 +2131,7 @@ void Spell::CleanupTargetList()
 class ProcReflectDelayed : public BasicEvent
 {
   public:
-    ProcReflectDelayed(Unit* owner, ObjectGuid casterGuid) : _victim(owner), _casterGuid(casterGuid)
-    {
-    }
+    ProcReflectDelayed(Unit* owner, ObjectGuid casterGuid) : _victim(owner), _casterGuid(casterGuid) {}
 
     bool Execute(uint64 /*e_time*/, uint32 /*p_time*/) override
     {
@@ -2390,173 +2353,168 @@ void Spell::AddItemTarget(Item* item, uint32 effectMask)
 
 void Spell::AddCorpseTarget(Corpse* corpse, uint32 effectMask)
 {
-        for (uint32 effIndex = 0; effIndex < MAX_SPELL_EFFECTS; ++effIndex)
-            if (!m_spellInfo->Effects[effIndex].IsEffect())
-                effectMask &= ~(1 << effIndex);
+    for (uint32 effIndex = 0; effIndex < MAX_SPELL_EFFECTS; ++effIndex)
+        if (!m_spellInfo->Effects[effIndex].IsEffect())
+            effectMask &= ~(1 << effIndex);
 
-        if (!effectMask)
-            return;
+    if (!effectMask)
+        return;
 
-        ObjectGuid targetGUID = corpse->GetGUID();
+    ObjectGuid targetGUID = corpse->GetGUID();
 
-        // Lookup target in already in list
-        auto ihit = std::find_if(std::begin(m_UniqueCorpseTargetInfo), std::end(m_UniqueCorpseTargetInfo), [targetGUID](CorpseTargetInfo const& target) { return target.TargetGUID == targetGUID; });
-        if (ihit != std::end(m_UniqueCorpseTargetInfo)) // Found in list
-        {
-            // Add only effect mask
-            ihit->EffectMask |= effectMask;
-            return;
-        }
+    // Lookup target in already in list
+    auto ihit = std::find_if(std::begin(m_UniqueCorpseTargetInfo), std::end(m_UniqueCorpseTargetInfo), [targetGUID](CorpseTargetInfo const& target) { return target.TargetGUID == targetGUID; });
+    if (ihit != std::end(m_UniqueCorpseTargetInfo)) // Found in list
+    {
+        // Add only effect mask
+        ihit->EffectMask |= effectMask;
+        return;
+    }
 
-        // This is new target calculate data for him
+    // This is new target calculate data for him
 
-        CorpseTargetInfo target;
-        target.TargetGUID = targetGUID;
-        target.EffectMask = effectMask;
+    CorpseTargetInfo target;
+    target.TargetGUID = targetGUID;
+    target.EffectMask = effectMask;
 
-        // Spell have speed - need calculate incoming time
-        if (m_spellInfo->Speed > 0.0f)
-        {
-            // calculate spell incoming interval
-            float dist = m_caster->GetDistance(corpse->GetPositionX(), corpse->GetPositionY(), corpse->GetPositionZ());
-            if (dist < 5.0f)
-                dist = 5.0f;
+    // Spell have speed - need calculate incoming time
+    if (m_spellInfo->Speed > 0.0f)
+    {
+        // calculate spell incoming interval
+        float dist = m_caster->GetDistance(corpse->GetPositionX(), corpse->GetPositionY(), corpse->GetPositionZ());
+        if (dist < 5.0f)
+            dist = 5.0f;
 
-            if (!m_spellInfo->HasAttribute(SPELL_ATTR9_SPECIAL_DELAY_CALCULATION))
-                target.TimeDelay = uint64(floor(dist / m_spellInfo->Speed * 1000.0f));
-            else
-                target.TimeDelay = uint64(float(m_spellInfo->Speed * 1000.0f));
-
-            if (!m_delayMoment || m_delayMoment > target.TimeDelay)
-                m_delayMoment = target.TimeDelay;
-        }
+        if (!m_spellInfo->HasAttribute(SPELL_ATTR9_SPECIAL_DELAY_CALCULATION))
+            target.TimeDelay = uint64(floor(dist / m_spellInfo->Speed * 1000.0f));
         else
-            target.TimeDelay = 0LL;
+            target.TimeDelay = uint64(float(m_spellInfo->Speed * 1000.0f));
 
-        // Add target to list
-        m_UniqueCorpseTargetInfo.emplace_back(std::move(target));
+        if (!m_delayMoment || m_delayMoment > target.TimeDelay)
+            m_delayMoment = target.TimeDelay;
+    }
+    else
+        target.TimeDelay = 0LL;
 
+    // Add target to list
+    m_UniqueCorpseTargetInfo.emplace_back(std::move(target));
 }
 
-void Spell::AddDestTarget(SpellDestination const& dest, uint32 effIndex)
-{
-    m_destTargets[effIndex] = dest;
-}
+void Spell::AddDestTarget(SpellDestination const& dest, uint32 effIndex) { m_destTargets[effIndex] = dest; }
 
 void Spell::TargetInfo::PreprocessTarget(Spell* spell)
 {
 
     Unit* unit = spell->m_caster->GetGUID() == TargetGUID ? spell->m_caster : ObjectAccessor::GetUnit(*spell->m_caster, TargetGUID);
-        if (!unit)
-            return;
+    if (!unit)
+        return;
 
-        // Need init unitTarget by default unit (can changed in code on reflect)
-        spell->unitTarget = unit;
+    // Need init unitTarget by default unit (can changed in code on reflect)
+    spell->unitTarget = unit;
 
-        // Reset damage/healing counter
-        spell->m_damage = Damage;
-        spell->m_healing = Healing;
+    // Reset damage/healing counter
+    spell->m_damage = Damage;
+    spell->m_healing = Healing;
 
-        _spellHitTarget = nullptr;
-        if (MissCondition == SPELL_MISS_NONE)
-            _spellHitTarget = unit;
-        else if (MissCondition == SPELL_MISS_REFLECT && ReflectResult == SPELL_MISS_NONE)
-            _spellHitTarget = spell->m_caster;
+    _spellHitTarget = nullptr;
+    if (MissCondition == SPELL_MISS_NONE)
+        _spellHitTarget = unit;
+    else if (MissCondition == SPELL_MISS_REFLECT && ReflectResult == SPELL_MISS_NONE)
+        _spellHitTarget = spell->m_caster;
 
-        _enablePVP = false; // need to check PvP state before spell effects, but act on it afterwards
-        if (_spellHitTarget)
+    _enablePVP = false; // need to check PvP state before spell effects, but act on it afterwards
+    if (_spellHitTarget)
+    {
+        // if target is flagged for pvp also flag caster if a player
+        if (unit->IsPvP() && spell->m_caster->GetTypeId() == TYPEID_PLAYER)
+            _enablePVP = true; // Decide on PvP flagging now, but act on it later.
+
+        SpellMissInfo missInfo = spell->PreprocessSpellHit(_spellHitTarget, ScaleAura, *this);
+        if (missInfo != SPELL_MISS_NONE)
         {
-            // if target is flagged for pvp also flag caster if a player
-            if (unit->IsPvP() && spell->m_caster->GetTypeId() == TYPEID_PLAYER)
-                _enablePVP = true; // Decide on PvP flagging now, but act on it later.
-
-            SpellMissInfo missInfo = spell->PreprocessSpellHit(_spellHitTarget, ScaleAura, *this);
-            if (missInfo != SPELL_MISS_NONE)
-            {
-                if (missInfo != SPELL_MISS_MISS)
+            if (missInfo != SPELL_MISS_MISS)
                 spell->m_caster->SendSpellMiss(unit, spell->m_spellInfo->Id, missInfo);
-                spell->m_damage = 0;
-                _spellHitTarget = nullptr;
-            }
+            spell->m_damage = 0;
+            _spellHitTarget = nullptr;
         }
+    }
 
-        spell->CallScriptOnHitHandlers();
+    spell->CallScriptOnHitHandlers();
 
-        // scripts can modify damage/healing for current target, save them
-        Damage = spell->m_damage;
-        Healing = spell->m_healing;
+    // scripts can modify damage/healing for current target, save them
+    Damage = spell->m_damage;
+    Healing = spell->m_healing;
 }
 
 void Spell::TargetInfo::DoTargetSpellHit(Spell* spell, uint8 effIndex)
 {
-        Unit* unit = spell->m_caster->GetGUID() == TargetGUID ? spell->m_caster : ObjectAccessor::GetUnit(*spell->m_caster, TargetGUID);
-        if (!unit)
-            return;
+    Unit* unit = spell->m_caster->GetGUID() == TargetGUID ? spell->m_caster : ObjectAccessor::GetUnit(*spell->m_caster, TargetGUID);
+    if (!unit)
+        return;
 
-        // Need init unitTarget by default unit (can changed in code on reflect)
-        // Or on missInfo != SPELL_MISS_NONE unitTarget undefined (but need in trigger subsystem)
-        spell->unitTarget = unit;
-        spell->targetMissInfo = MissCondition;
+    // Need init unitTarget by default unit (can changed in code on reflect)
+    // Or on missInfo != SPELL_MISS_NONE unitTarget undefined (but need in trigger subsystem)
+    spell->unitTarget = unit;
+    spell->targetMissInfo = MissCondition;
 
-        // Reset damage/healing counter
-        spell->m_damage = Damage;
-        spell->m_healing = Healing;
+    // Reset damage/healing counter
+    spell->m_damage = Damage;
+    spell->m_healing = Healing;
 
-        if (unit->IsAlive() != IsAlive)
-            return;
+    if (unit->IsAlive() != IsAlive)
+        return;
 
-        if (spell->getState() == SPELL_STATE_DELAYED && !spell->IsPositive() && (GameTime::GetGameTimeMS() - TimeDelay) <= unit->m_lastSanctuaryTime)
-            return; // No missinfo in that case
+    if (spell->getState() == SPELL_STATE_DELAYED && !spell->IsPositive() && (GameTime::GetGameTimeMS() - TimeDelay) <= unit->m_lastSanctuaryTime)
+        return; // No missinfo in that case
 
-        if (_spellHitTarget)
-            spell->DoSpellEffectHit(_spellHitTarget, effIndex, *this);
+    if (_spellHitTarget)
+        spell->DoSpellEffectHit(_spellHitTarget, effIndex, *this);
 
-        // scripts can modify damage/healing for current target, save them
-        Damage = spell->m_damage;
-        Healing = spell->m_healing;
+    // scripts can modify damage/healing for current target, save them
+    Damage = spell->m_damage;
+    Healing = spell->m_healing;
 }
 
 void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
 {
-        Unit* unit = spell->m_caster->GetGUID() == TargetGUID ? spell->m_caster : ObjectAccessor::GetUnit(*spell->m_caster, TargetGUID);
-        if (!unit)
-            return;
+    Unit* unit = spell->m_caster->GetGUID() == TargetGUID ? spell->m_caster : ObjectAccessor::GetUnit(*spell->m_caster, TargetGUID);
+    if (!unit)
+        return;
 
-        // other targets executed before this one changed pointer
-        spell->unitTarget = unit;
-        if (_spellHitTarget)
-            spell->unitTarget = _spellHitTarget;
+    // other targets executed before this one changed pointer
+    spell->unitTarget = unit;
+    if (_spellHitTarget)
+        spell->unitTarget = _spellHitTarget;
 
-        // Reset damage/healing counter
-        spell->m_damage = Damage;
-        spell->m_healing = Healing;
+    // Reset damage/healing counter
+    spell->m_damage = Damage;
+    spell->m_healing = Healing;
 
-        // Get original caster (if exist) and calculate damage/healing from him data
-        // Skip if m_originalCaster not available
-        Unit* caster = spell->m_originalCaster ? spell->m_originalCaster : spell->m_caster;
-        if (!caster)
-            return;
+    // Get original caster (if exist) and calculate damage/healing from him data
+    // Skip if m_originalCaster not available
+    Unit* caster = spell->m_originalCaster ? spell->m_originalCaster : spell->m_caster;
+    if (!caster)
+        return;
 
-        // Fill base trigger info
-        uint32 procAttacker = spell->m_procAttacker;
-        uint32 procVictim = spell->m_procVictim;
-        uint32 procSpellType = PROC_SPELL_TYPE_NONE;
-        uint32 hitMask = PROC_HIT_NONE;
+    // Fill base trigger info
+    uint32 procAttacker = spell->m_procAttacker;
+    uint32 procVictim = spell->m_procVictim;
+    uint32 procSpellType = PROC_SPELL_TYPE_NONE;
+    uint32 hitMask = PROC_HIT_NONE;
 
-        // Spells with this flag cannot trigger if effect is cast on self
-        bool const canEffectTrigger =
-            (!spell->m_spellInfo->HasAttribute(SPELL_ATTR3_SUPPRESS_CASTER_PROCS) || !spell->m_spellInfo->HasAttribute(SPELL_ATTR3_SUPPRESS_TARGET_PROCS))
-                                      &&spell->unitTarget->CanProc() && (spell->CanExecuteTriggersOnHit(EffectMask) || MissCondition == SPELL_MISS_IMMUNE || MissCondition == SPELL_MISS_IMMUNE2);
-        // Trigger info was not filled in Spell::prepareDataForTriggerSystem - we do it now
-        if (canEffectTrigger && !procAttacker && !procVictim)
+    // Spells with this flag cannot trigger if effect is cast on self
+    bool const canEffectTrigger = (!spell->m_spellInfo->HasAttribute(SPELL_ATTR3_SUPPRESS_CASTER_PROCS) || !spell->m_spellInfo->HasAttribute(SPELL_ATTR3_SUPPRESS_TARGET_PROCS)) &&
+                                  spell->unitTarget->CanProc() && (spell->CanExecuteTriggersOnHit(EffectMask) || MissCondition == SPELL_MISS_IMMUNE || MissCondition == SPELL_MISS_IMMUNE2);
+    // Trigger info was not filled in Spell::prepareDataForTriggerSystem - we do it now
+    if (canEffectTrigger && !procAttacker && !procVictim)
+    {
+        bool positive = true;
+        if (spell->m_damage > 0)
+            positive = false;
+        else if (!spell->m_healing)
         {
-            bool positive = true;
-            if (spell->m_damage > 0)
-                positive = false;
-            else if (!spell->m_healing)
+            for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
             {
-                for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
-                {
                 // in case of immunity, check all effects to choose correct procFlags, as none has technically hit
                 if (EffectMask && !(EffectMask & (1 << i)))
                     continue;
@@ -2566,20 +2524,20 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
                     positive = false;
                     break;
                 }
-                }
             }
+        }
 
-            switch (spell->m_spellInfo->DmgClass)
+        switch (spell->m_spellInfo->DmgClass)
+        {
+        case SPELL_DAMAGE_CLASS_NONE:
+        case SPELL_DAMAGE_CLASS_MAGIC:
+            if (spell->m_spellInfo->HasAttribute(SPELL_ATTR3_TREAT_AS_PERIODIC))
             {
-            case SPELL_DAMAGE_CLASS_NONE:
-            case SPELL_DAMAGE_CLASS_MAGIC:
-                if (spell->m_spellInfo->HasAttribute(SPELL_ATTR3_TREAT_AS_PERIODIC))
-                {
                 procAttacker |= PROC_FLAG_DEAL_PERIODIC;
                 procVictim |= PROC_FLAG_TAKE_PERIODIC;
-                }
-                else if (spell->m_spellInfo->HasAttribute(SPELL_ATTR0_IS_ABILITY))
-                {
+            }
+            else if (spell->m_spellInfo->HasAttribute(SPELL_ATTR0_IS_ABILITY))
+            {
                 if (positive)
                 {
                     procAttacker |= PROC_FLAG_DEAL_HELPFUL_ABILITY;
@@ -2590,9 +2548,9 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
                     procAttacker |= PROC_FLAG_DEAL_HARMFUL_ABILITY;
                     procVictim |= PROC_FLAG_TAKE_HARMFUL_ABILITY;
                 }
-                }
-                else
-                {
+            }
+            else
+            {
                 if (positive)
                 {
                     procAttacker |= PROC_FLAG_DEAL_HELPFUL_SPELL;
@@ -2603,177 +2561,177 @@ void Spell::TargetInfo::DoDamageAndTriggers(Spell* spell)
                     procAttacker |= PROC_FLAG_DEAL_HARMFUL_SPELL;
                     procVictim |= PROC_FLAG_TAKE_HARMFUL_SPELL;
                 }
-                }
-                break;
             }
+            break;
         }
+    }
 
-        // All calculated do it!
-        // Do healing
-        std::unique_ptr<DamageInfo> spellDamageInfo;
-        std::unique_ptr<HealInfo> healInfo;
-        if (spell->m_healing > 0)
+    // All calculated do it!
+    // Do healing
+    std::unique_ptr<DamageInfo> spellDamageInfo;
+    std::unique_ptr<HealInfo> healInfo;
+    if (spell->m_healing > 0)
+    {
+        uint32 addhealth = spell->m_healing;
+        if (IsCrit)
         {
-            uint32 addhealth = spell->m_healing;
-            if (IsCrit)
-            {
-                hitMask |= PROC_HIT_CRITICAL;
-                addhealth = Unit::SpellCriticalHealingBonus(caster, addhealth);
-            }
-            else
-                hitMask |= PROC_HIT_NORMAL;
-
-            healInfo = std::make_unique<HealInfo>(caster, spell->unitTarget, addhealth, spell->m_spellInfo, spell->m_spellInfo->GetSchoolMask());
-            caster->HealBySpell(*healInfo, IsCrit);
-            spell->unitTarget->GetThreatManager().ForwardThreatForAssistingMe(caster, float(healInfo->GetEffectiveHeal()) * 0.5f, spell->m_spellInfo);
-            spell->m_healing = healInfo->GetEffectiveHeal();
-
-            procSpellType |= PROC_SPELL_TYPE_HEAL;
+            hitMask |= PROC_HIT_CRITICAL;
+            addhealth = Unit::SpellCriticalHealingBonus(caster, addhealth);
         }
+        else
+            hitMask |= PROC_HIT_NORMAL;
 
-        // Do damage
-        if (spell->m_damage > 0)
+        healInfo = std::make_unique<HealInfo>(caster, spell->unitTarget, addhealth, spell->m_spellInfo, spell->m_spellInfo->GetSchoolMask());
+        caster->HealBySpell(*healInfo, IsCrit);
+        spell->unitTarget->GetThreatManager().ForwardThreatForAssistingMe(caster, float(healInfo->GetEffectiveHeal()) * 0.5f, spell->m_spellInfo);
+        spell->m_healing = healInfo->GetEffectiveHeal();
+
+        procSpellType |= PROC_SPELL_TYPE_HEAL;
+    }
+
+    // Do damage
+    if (spell->m_damage > 0)
+    {
+        // Fill base damage struct (unitTarget - is real spell target)
+        SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, spell->m_spellSchoolMask);
+        // Check damage immunity
+        if (spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo))
         {
-            // Fill base damage struct (unitTarget - is real spell target)
-            SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, spell->m_spellSchoolMask);
-            // Check damage immunity
-            if (spell->unitTarget->IsImmunedToDamage(spell->m_spellInfo))
-            {
-                hitMask = PROC_HIT_IMMUNE;
-                spell->m_damage = 0;
+            hitMask = PROC_HIT_IMMUNE;
+            spell->m_damage = 0;
 
-                // no packet found in sniffs
-            }
-            else
-            {
-                // Add bonuses and fill damageInfo struct
-                caster->CalculateSpellDamageTaken(&damageInfo, spell->m_damage, spell->m_spellInfo, spell->m_attackType, IsCrit);
-                Unit::DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb);
+            // no packet found in sniffs
+        }
+        else
+        {
+            // Add bonuses and fill damageInfo struct
+            caster->CalculateSpellDamageTaken(&damageInfo, spell->m_damage, spell->m_spellInfo, spell->m_attackType, IsCrit);
+            Unit::DealDamageMods(damageInfo.target, damageInfo.damage, &damageInfo.absorb);
 
-                if (Creature* target = damageInfo.target->ToCreature())
+            if (Creature* target = damageInfo.target->ToCreature())
                 if (caster->IsCreature() && !caster->IsCharmedOwnedByPlayerOrPlayer())
                     if (target->GetNoNpcDamageBelowPctHealthValue() != 0.0f)
                         if (target->GetHealthPct() <= target->GetNoNpcDamageBelowPctHealthValue())
                             damageInfo.damage = 0; // Send log damage message to client
-                caster->SendSpellNonMeleeDamageLog(&damageInfo);
+            caster->SendSpellNonMeleeDamageLog(&damageInfo);
 
-                hitMask |= createProcHitMask(&damageInfo, MissCondition);
-                procVictim |= PROC_FLAG_TAKE_ANY_DAMAGE;
-
-                spell->m_damage = damageInfo.damage;
-                caster->DealSpellDamage(&damageInfo, true);
-            }
-
-            // Do triggers for unit
-            if (canEffectTrigger)
-            {
-                spellDamageInfo = std::make_unique<DamageInfo>(damageInfo, SPELL_DIRECT_DAMAGE, spell->m_attackType, hitMask);
-                procSpellType |= PROC_SPELL_TYPE_DAMAGE;
-
-                if (caster->GetTypeId() == TYPEID_PLAYER && !spell->m_spellInfo->HasAttribute(SPELL_ATTR0_CANCELS_AUTO_ATTACK_COMBAT) &&
-                    !spell->m_spellInfo->HasAttribute(SPELL_ATTR4_CANT_TRIGGER_ITEM_SPELLS) &&
-                    (spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_MELEE || spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_RANGED))
-                caster->ToPlayer()->CastItemCombatSpell(*spellDamageInfo);
-            }
-        }
-
-        // Passive spell hits/misses or active spells only misses (only triggers)
-        if (spell->m_damage <= 0 && spell->m_healing <= 0)
-        {
-            // Fill base damage struct (unitTarget - is real spell target)
-            SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, spell->m_spellSchoolMask);
             hitMask |= createProcHitMask(&damageInfo, MissCondition);
-            // Do triggers for unit
-            if (canEffectTrigger)
-            {
-                if (spell->m_spellInfo->HasAttribute(SPELL_ATTR3_SUPPRESS_CASTER_PROCS))
-                procAttacker = PROC_FLAG_NONE;
+            procVictim |= PROC_FLAG_TAKE_ANY_DAMAGE;
 
-                if (spell->m_spellInfo->HasAttribute(SPELL_ATTR3_SUPPRESS_TARGET_PROCS))
-                procVictim = PROC_FLAG_NONE;
-                spellDamageInfo = std::make_unique<DamageInfo>(damageInfo, NODAMAGE, spell->m_attackType, hitMask);
-                procSpellType |= PROC_SPELL_TYPE_NO_DMG_HEAL;
-            }
-
-            // Failed Pickpocket, reveal rogue
-            if (MissCondition == SPELL_MISS_RESIST && spell->m_spellInfo->HasAttribute(SPELL_ATTR0_CU_PICKPOCKET) && spell->unitTarget->GetTypeId() == TYPEID_UNIT)
-            {
-                spell->m_caster->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags::Interacting);
-                spell->unitTarget->ToCreature()->EngageWithTarget(spell->m_caster);
-            }
+            spell->m_damage = damageInfo.damage;
+            caster->DealSpellDamage(&damageInfo, true);
         }
 
         // Do triggers for unit
         if (canEffectTrigger)
         {
-            Unit::ProcSkillsAndAuras(caster, spell->unitTarget, procAttacker, procVictim, procSpellType, PROC_SPELL_PHASE_HIT, hitMask, spell, spellDamageInfo.get(), healInfo.get());
+            spellDamageInfo = std::make_unique<DamageInfo>(damageInfo, SPELL_DIRECT_DAMAGE, spell->m_attackType, hitMask);
+            procSpellType |= PROC_SPELL_TYPE_DAMAGE;
 
-            // item spells (spell hit of non-damage spell may also activate items, for example seal of corruption hidden hit)
-            if (caster->GetTypeId() == TYPEID_PLAYER && (procSpellType & (PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_NO_DMG_HEAL)))
-            {
-                if (spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_MELEE || spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_RANGED)
+            if (caster->GetTypeId() == TYPEID_PLAYER && !spell->m_spellInfo->HasAttribute(SPELL_ATTR0_CANCELS_AUTO_ATTACK_COMBAT) &&
+                !spell->m_spellInfo->HasAttribute(SPELL_ATTR4_CANT_TRIGGER_ITEM_SPELLS) &&
+                (spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_MELEE || spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_RANGED))
+                caster->ToPlayer()->CastItemCombatSpell(*spellDamageInfo);
+        }
+    }
+
+    // Passive spell hits/misses or active spells only misses (only triggers)
+    if (spell->m_damage <= 0 && spell->m_healing <= 0)
+    {
+        // Fill base damage struct (unitTarget - is real spell target)
+        SpellNonMeleeDamage damageInfo(caster, spell->unitTarget, spell->m_spellInfo->Id, spell->m_spellSchoolMask);
+        hitMask |= createProcHitMask(&damageInfo, MissCondition);
+        // Do triggers for unit
+        if (canEffectTrigger)
+        {
+            if (spell->m_spellInfo->HasAttribute(SPELL_ATTR3_SUPPRESS_CASTER_PROCS))
+                procAttacker = PROC_FLAG_NONE;
+
+            if (spell->m_spellInfo->HasAttribute(SPELL_ATTR3_SUPPRESS_TARGET_PROCS))
+                procVictim = PROC_FLAG_NONE;
+            spellDamageInfo = std::make_unique<DamageInfo>(damageInfo, NODAMAGE, spell->m_attackType, hitMask);
+            procSpellType |= PROC_SPELL_TYPE_NO_DMG_HEAL;
+        }
+
+        // Failed Pickpocket, reveal rogue
+        if (MissCondition == SPELL_MISS_RESIST && spell->m_spellInfo->HasAttribute(SPELL_ATTR0_CU_PICKPOCKET) && spell->unitTarget->GetTypeId() == TYPEID_UNIT)
+        {
+            spell->m_caster->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags::Interacting);
+            spell->unitTarget->ToCreature()->EngageWithTarget(spell->m_caster);
+        }
+    }
+
+    // Do triggers for unit
+    if (canEffectTrigger)
+    {
+        Unit::ProcSkillsAndAuras(caster, spell->unitTarget, procAttacker, procVictim, procSpellType, PROC_SPELL_PHASE_HIT, hitMask, spell, spellDamageInfo.get(), healInfo.get());
+
+        // item spells (spell hit of non-damage spell may also activate items, for example seal of corruption hidden hit)
+        if (caster->GetTypeId() == TYPEID_PLAYER && (procSpellType & (PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_NO_DMG_HEAL)))
+        {
+            if (spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_MELEE || spell->m_spellInfo->DmgClass == SPELL_DAMAGE_CLASS_RANGED)
                 if (!spell->m_spellInfo->HasAttribute(SPELL_ATTR0_CANCELS_AUTO_ATTACK_COMBAT) && !spell->m_spellInfo->HasAttribute(SPELL_ATTR4_CANT_TRIGGER_ITEM_SPELLS))
                     caster->ToPlayer()->CastItemCombatSpell(*spellDamageInfo);
-            }
         }
+    }
 
-        // set hitmask for finish procs
-        spell->m_hitMask |= hitMask;
+    // set hitmask for finish procs
+    spell->m_hitMask |= hitMask;
 
-        // Do not take combo points on dodge and miss
-        if (MissCondition != SPELL_MISS_NONE && spell->m_needComboPoints && spell->m_targets.GetUnitTargetGUID() == TargetGUID)
-            spell->m_needComboPoints = false;
+    // Do not take combo points on dodge and miss
+    if (MissCondition != SPELL_MISS_NONE && spell->m_needComboPoints && spell->m_targets.GetUnitTargetGUID() == TargetGUID)
+        spell->m_needComboPoints = false;
 
-        // _spellHitTarget can be null if spell is missed in DoSpellHitOnUnit
-        if (MissCondition != SPELL_MISS_EVADE && _spellHitTarget && !spell->m_caster->IsFriendlyTo(unit) && (!spell->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)))
-        {
-            if (Unit* unitCaster = spell->m_caster->ToUnit())
-                if (!unitCaster->IsCreature() || !unitCaster->ToCreature()->IsTrigger())
+    // _spellHitTarget can be null if spell is missed in DoSpellHitOnUnit
+    if (MissCondition != SPELL_MISS_EVADE && _spellHitTarget && !spell->m_caster->IsFriendlyTo(unit) && (!spell->IsPositive() || spell->m_spellInfo->HasEffect(SPELL_EFFECT_DISPEL)))
+    {
+        if (Unit* unitCaster = spell->m_caster->ToUnit())
+            if (!unitCaster->IsCreature() || !unitCaster->ToCreature()->IsTrigger())
                 unitCaster->AtTargetAttacked(unit, spell->m_spellInfo->CausesInitialThreat() && !unitCaster->IsIgnoringCombat());
 
-            if (!unit->IsStandState())
-                unit->SetStandState(UNIT_STAND_STATE_STAND);
-        }
+        if (!unit->IsStandState())
+            unit->SetStandState(UNIT_STAND_STATE_STAND);
+    }
 
-        // Check for SPELL_ATTR7_INTERRUPT_ONLY_NONPLAYER
-        if (MissCondition == SPELL_MISS_NONE && spell->m_spellInfo->HasAttribute(SPELL_ATTR7_INTERRUPT_ONLY_NONPLAYER) && unit->GetTypeId() != TYPEID_PLAYER)
-            caster->CastSpell(unit, SPELL_INTERRUPT_NONPLAYER, true);
+    // Check for SPELL_ATTR7_INTERRUPT_ONLY_NONPLAYER
+    if (MissCondition == SPELL_MISS_NONE && spell->m_spellInfo->HasAttribute(SPELL_ATTR7_INTERRUPT_ONLY_NONPLAYER) && unit->GetTypeId() != TYPEID_PLAYER)
+        caster->CastSpell(unit, SPELL_INTERRUPT_NONPLAYER, true);
 
-        if (_spellHitTarget)
-        {
-            // AI functions
-            if (_spellHitTarget->GetTypeId() == TYPEID_UNIT)
-                if (_spellHitTarget->ToCreature()->IsAIEnabled())
+    if (_spellHitTarget)
+    {
+        // AI functions
+        if (_spellHitTarget->GetTypeId() == TYPEID_UNIT)
+            if (_spellHitTarget->ToCreature()->IsAIEnabled())
                 _spellHitTarget->ToCreature()->AI()->SpellHit(spell->m_caster, spell->m_spellInfo);
 
-            if (spell->m_caster->GetTypeId() == TYPEID_UNIT && spell->m_caster->ToCreature()->IsAIEnabled())
-                spell->m_caster->ToCreature()->AI()->SpellHitTarget(_spellHitTarget, spell->m_spellInfo);
+        if (spell->m_caster->GetTypeId() == TYPEID_UNIT && spell->m_caster->ToCreature()->IsAIEnabled())
+            spell->m_caster->ToCreature()->AI()->SpellHitTarget(_spellHitTarget, spell->m_spellInfo);
 
-            // Needs to be called after dealing damage/healing to not remove breaking on damage auras
-            spell->DoTriggersOnSpellHit(_spellHitTarget, EffectMask);
+        // Needs to be called after dealing damage/healing to not remove breaking on damage auras
+        spell->DoTriggersOnSpellHit(_spellHitTarget, EffectMask);
 
-            if (_enablePVP)
-                spell->m_caster->ToPlayer()->UpdatePvP(true);
-        }
+        if (_enablePVP)
+            spell->m_caster->ToPlayer()->UpdatePvP(true);
+    }
 
-        spell->CallScriptAfterHitHandlers();
+    spell->CallScriptAfterHitHandlers();
 }
 
 void Spell::GOTargetInfo::DoTargetSpellHit(Spell* spell, uint8 effIndex)
 {
-        GameObject* go = ObjectAccessor::GetGameObject(*spell->m_caster, TargetGUID);
-        if (!go)
-            return;
+    GameObject* go = ObjectAccessor::GetGameObject(*spell->m_caster, TargetGUID);
+    if (!go)
+        return;
 
-        spell->CallScriptBeforeHitHandlers();
+    spell->CallScriptBeforeHitHandlers();
 
-        spell->HandleEffects(nullptr, nullptr, go, nullptr, effIndex, SPELL_EFFECT_HANDLE_HIT_TARGET);
+    spell->HandleEffects(nullptr, nullptr, go, nullptr, effIndex, SPELL_EFFECT_HANDLE_HIT_TARGET);
 
-        if (go->AI())
-            go->AI()->SpellHit(spell->m_caster, spell->m_spellInfo);
+    if (go->AI())
+        go->AI()->SpellHit(spell->m_caster, spell->m_spellInfo);
 
-        spell->CallScriptOnHitHandlers();
-        spell->CallScriptAfterHitHandlers();
+    spell->CallScriptOnHitHandlers();
+    spell->CallScriptAfterHitHandlers();
 }
 
 void Spell::DoTriggersOnSpellHit(Unit* unit, uint8 effMask)
@@ -2885,68 +2843,68 @@ SpellMissInfo Spell::PreprocessSpellHit(Unit* unit, bool scaleAura, TargetInfo& 
             unit->RemoveAurasWithInterruptFlags(SpellAuraInterruptFlags::HostileActionReceived);
     }
 
-// check immunity due to diminishing returns
-if (m_originalCaster && Aura::BuildEffectMaskForOwner(m_spellInfo, MAX_EFFECT_MASK, unit))
-{
-    // Select rank for aura with level requirements only in specific cases
-    // Unit has to be target only of aura effect, both caster and target have to be players, target has to be other than unit target
-    hitInfo.AuraSpellInfo = m_spellInfo;
-    if (scaleAura)
+    // check immunity due to diminishing returns
+    if (m_originalCaster && Aura::BuildEffectMaskForOwner(m_spellInfo, MAX_EFFECT_MASK, unit))
     {
-        if (SpellInfo const* actualSpellInfo = m_spellInfo->GetAuraRankForLevel(unitTarget->getLevel()))
-            hitInfo.AuraSpellInfo = actualSpellInfo;
-
-        for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+        // Select rank for aura with level requirements only in specific cases
+        // Unit has to be target only of aura effect, both caster and target have to be players, target has to be other than unit target
+        hitInfo.AuraSpellInfo = m_spellInfo;
+        if (scaleAura)
         {
-            hitInfo.AuraBasePoints[i] = hitInfo.AuraSpellInfo->Effects[i].BasePoints;
-            if (m_spellInfo->Effects[i].Effect != hitInfo.AuraSpellInfo->Effects[i].Effect)
+            if (SpellInfo const* actualSpellInfo = m_spellInfo->GetAuraRankForLevel(unitTarget->getLevel()))
+                hitInfo.AuraSpellInfo = actualSpellInfo;
+
+            for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
             {
-                hitInfo.AuraSpellInfo = m_spellInfo;
-                break;
+                hitInfo.AuraBasePoints[i] = hitInfo.AuraSpellInfo->Effects[i].BasePoints;
+                if (m_spellInfo->Effects[i].Effect != hitInfo.AuraSpellInfo->Effects[i].Effect)
+                {
+                    hitInfo.AuraSpellInfo = m_spellInfo;
+                    break;
+                }
             }
         }
-    }
 
-    // Get Data Needed for Diminishing Returns, some effects may have multiple auras, so this must be done on spell hit, not aura add
-    bool triggered = (m_triggeredByAuraSpell != nullptr);
-    hitInfo.DRGroup = m_spellInfo->GetDiminishingReturnsGroupForSpell(triggered);
+        // Get Data Needed for Diminishing Returns, some effects may have multiple auras, so this must be done on spell hit, not aura add
+        bool triggered = (m_triggeredByAuraSpell != nullptr);
+        hitInfo.DRGroup = m_spellInfo->GetDiminishingReturnsGroupForSpell(triggered);
 
-    DiminishingLevels diminishLevel = DIMINISHING_LEVEL_1;
-    if (hitInfo.DRGroup)
-    {
-        diminishLevel = unit->GetDiminishing(hitInfo.DRGroup);
-        DiminishingReturnsType type = m_spellInfo->GetDiminishingReturnsGroupType(triggered);
-        // Increase Diminishing on unit, current informations for actually casts will use values above
-        if (type == DRTYPE_ALL || (type == DRTYPE_PLAYER && unit->IsAffectedByDiminishingReturns()))
-            unit->IncrDiminishing(m_spellInfo, triggered);
-    }
-
-    // Now Reduce spell duration using data received at spell hit
-    // check whatever effects we're going to apply, diminishing returns only apply to negative aura effects
-    hitInfo.Positive = true;
-    if (m_originalCaster == unit || !m_originalCaster->IsFriendlyTo(unit))
-    {
-        for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
+        DiminishingLevels diminishLevel = DIMINISHING_LEVEL_1;
+        if (hitInfo.DRGroup)
         {
-            // mod duration only for effects applying aura!
-            if (hitInfo.EffectMask & (1 << i) && hitInfo.AuraSpellInfo->Effects[i].IsUnitOwnedAuraEffect() && !hitInfo.AuraSpellInfo->IsPositiveEffect(i))
+            diminishLevel = unit->GetDiminishing(hitInfo.DRGroup);
+            DiminishingReturnsType type = m_spellInfo->GetDiminishingReturnsGroupType(triggered);
+            // Increase Diminishing on unit, current informations for actually casts will use values above
+            if (type == DRTYPE_ALL || (type == DRTYPE_PLAYER && unit->IsAffectedByDiminishingReturns()))
+                unit->IncrDiminishing(m_spellInfo, triggered);
+        }
+
+        // Now Reduce spell duration using data received at spell hit
+        // check whatever effects we're going to apply, diminishing returns only apply to negative aura effects
+        hitInfo.Positive = true;
+        if (m_originalCaster == unit || !m_originalCaster->IsFriendlyTo(unit))
+        {
+            for (uint8 i = 0; i < MAX_SPELL_EFFECTS; ++i)
             {
-                hitInfo.Positive = false;
-                break;
+                // mod duration only for effects applying aura!
+                if (hitInfo.EffectMask & (1 << i) && hitInfo.AuraSpellInfo->Effects[i].IsUnitOwnedAuraEffect() && !hitInfo.AuraSpellInfo->IsPositiveEffect(i))
+                {
+                    hitInfo.Positive = false;
+                    break;
+                }
             }
         }
+
+        hitInfo.AuraDuration = hitInfo.AuraSpellInfo->GetMaxDuration();
+
+        // unit is immune to aura if it was diminished to 0 duration
+        if (!hitInfo.Positive && !unit->ApplyDiminishingToDuration(hitInfo.AuraSpellInfo, triggered, hitInfo.AuraDuration, m_originalCaster, diminishLevel))
+            if (std::all_of(std::begin(hitInfo.AuraSpellInfo->Effects), std::end(hitInfo.AuraSpellInfo->Effects),
+                    [](SpellEffectInfo const& effInfo) { return !effInfo.IsEffect() || effInfo.Effect == SPELL_EFFECT_APPLY_AURA; }))
+                return SPELL_MISS_IMMUNE;
     }
 
-    hitInfo.AuraDuration = hitInfo.AuraSpellInfo->GetMaxDuration();
-
-    // unit is immune to aura if it was diminished to 0 duration
-    if (!hitInfo.Positive && !unit->ApplyDiminishingToDuration(hitInfo.AuraSpellInfo, triggered, hitInfo.AuraDuration, m_originalCaster, diminishLevel))
-        if (std::all_of(std::begin(hitInfo.AuraSpellInfo->Effects), std::end(hitInfo.AuraSpellInfo->Effects),
-                [](SpellEffectInfo const& effInfo) { return !effInfo.IsEffect() || effInfo.Effect == SPELL_EFFECT_APPLY_AURA; }))
-            return SPELL_MISS_IMMUNE;
-}
-
-return SPELL_MISS_NONE;
+    return SPELL_MISS_NONE;
 }
 
 void Spell::DoSpellEffectHit(Unit* unit, uint8 effIndex, TargetInfo& hitInfo)
@@ -2960,14 +2918,13 @@ void Spell::DoSpellEffectHit(Unit* unit, uint8 effIndex, TargetInfo& hitInfo)
 
             if (!_spellAura)
             {
-                bool const resetPeriodicTimer = false; //!(_triggeredCastFlags & TRIGGERED_DONT_RESET_PERIODIC_TIMER);
                 uint8 const allAuraEffectMask = Aura::BuildEffectMaskForOwner(hitInfo.AuraSpellInfo, MAX_EFFECT_MASK, unit);
                 int32 const* bp = hitInfo.AuraBasePoints;
                 if (hitInfo.AuraSpellInfo == m_spellInfo)
                     bp = m_spellValue->EffectBasePoints;
 
                 AuraCreateInfo createInfo(hitInfo.AuraSpellInfo, allAuraEffectMask, unit);
-                createInfo.SetCaster(m_originalCaster).SetBaseAmount(bp).SetCastItem(m_CastItem).SetPeriodicReset(resetPeriodicTimer).SetOwnerEffectMask(aura_effmask).IsRefresh = &refresh;
+                createInfo.SetCaster(m_originalCaster).SetBaseAmount(bp).SetCastItem(m_CastItem).SetOwnerEffectMask(aura_effmask).IsRefresh = &refresh;
                 if (Aura* aura = Aura::TryRefreshStackOrCreate(createInfo))
                     _spellAura = aura->ToUnitAura();
             }
@@ -3673,7 +3630,7 @@ void Spell::handle_immediate()
         m_hitMask = PROC_HIT_NORMAL;
     else
 
-    DoProcessTargetContainer(m_UniqueTargetInfo);
+        DoProcessTargetContainer(m_UniqueTargetInfo);
 
     DoProcessTargetContainer(m_UniqueGOTargetInfo);
     DoProcessTargetContainer(m_UniqueCorpseTargetInfo);
@@ -3722,42 +3679,42 @@ uint64 Spell::handle_delayed(uint64 t_offset)
     // now recheck units targeting correctness (need before any effects apply to prevent adding immunity at first effect not allow apply second spell effect and similar cases)
     {
         std::vector<TargetInfo> delayedTargets;
-    auto itr = std::remove_if(std::begin(m_UniqueTargetInfo), std::end(m_UniqueTargetInfo),
-        [&](TargetInfo& target) -> bool
-        {
-            if (single_missile || target.TimeDelay <= t_offset)
+        auto itr = std::remove_if(std::begin(m_UniqueTargetInfo), std::end(m_UniqueTargetInfo),
+            [&](TargetInfo& target) -> bool
             {
-                target.TimeDelay = t_offset;
-                return true;
-            }
-            else if (next_time == 0 || target.TimeDelay < next_time)
-                next_time = target.TimeDelay;
+                if (single_missile || target.TimeDelay <= t_offset)
+                {
+                    target.TimeDelay = t_offset;
+                    return true;
+                }
+                else if (next_time == 0 || target.TimeDelay < next_time)
+                    next_time = target.TimeDelay;
 
-            return false;
-        });
+                return false;
+            });
 
-    delayedTargets.insert(delayedTargets.end(), std::make_move_iterator(itr), std::make_move_iterator(m_UniqueTargetInfo.end()));
-    m_UniqueTargetInfo.erase(itr, m_UniqueTargetInfo.end());
+        delayedTargets.insert(delayedTargets.end(), std::make_move_iterator(itr), std::make_move_iterator(m_UniqueTargetInfo.end()));
+        m_UniqueTargetInfo.erase(itr, m_UniqueTargetInfo.end());
 
-    DoProcessTargetContainer(delayedTargets);
+        DoProcessTargetContainer(delayedTargets);
     }
 
-  // now recheck gameobject targeting correctness
+    // now recheck gameobject targeting correctness
     {
         std::vector<GOTargetInfo> delayedGOTargets;
         auto itr = std::remove_if(std::begin(m_UniqueGOTargetInfo), std::end(m_UniqueGOTargetInfo),
-        [&](GOTargetInfo& goTarget) -> bool
-        {
-            if (single_missile || goTarget.TimeDelay <= t_offset)
+            [&](GOTargetInfo& goTarget) -> bool
             {
-                goTarget.TimeDelay = t_offset;
-                return true;
-            }
-            else if (next_time == 0 || goTarget.TimeDelay < next_time)
-                next_time = goTarget.TimeDelay;
+                if (single_missile || goTarget.TimeDelay <= t_offset)
+                {
+                    goTarget.TimeDelay = t_offset;
+                    return true;
+                }
+                else if (next_time == 0 || goTarget.TimeDelay < next_time)
+                    next_time = goTarget.TimeDelay;
 
-            return false;
-        });
+                return false;
+            });
         delayedGOTargets.insert(delayedGOTargets.end(), std::make_move_iterator(itr), std::make_move_iterator(m_UniqueGOTargetInfo.end()));
         m_UniqueGOTargetInfo.erase(itr, m_UniqueGOTargetInfo.end());
         DoProcessTargetContainer(delayedGOTargets);
@@ -3767,23 +3724,23 @@ uint64 Spell::handle_delayed(uint64 t_offset)
     {
         std::vector<CorpseTargetInfo> delayedCorpseTargets;
         auto itr = std::remove_if(std::begin(m_UniqueCorpseTargetInfo), std::end(m_UniqueCorpseTargetInfo),
-        [&](CorpseTargetInfo& goTarget) -> bool
-        {
-            if (single_missile || goTarget.TimeDelay <= t_offset)
+            [&](CorpseTargetInfo& goTarget) -> bool
             {
-                goTarget.TimeDelay = t_offset;
-                return true;
-            }
-            else if (next_time == 0 || goTarget.TimeDelay < next_time)
-                next_time = goTarget.TimeDelay;
+                if (single_missile || goTarget.TimeDelay <= t_offset)
+                {
+                    goTarget.TimeDelay = t_offset;
+                    return true;
+                }
+                else if (next_time == 0 || goTarget.TimeDelay < next_time)
+                    next_time = goTarget.TimeDelay;
 
-            return false;
-        });
+                return false;
+            });
 
-    delayedCorpseTargets.insert(delayedCorpseTargets.end(), std::make_move_iterator(itr), std::make_move_iterator(m_UniqueCorpseTargetInfo.end()));
-    m_UniqueCorpseTargetInfo.erase(itr, m_UniqueCorpseTargetInfo.end());
+        delayedCorpseTargets.insert(delayedCorpseTargets.end(), std::make_move_iterator(itr), std::make_move_iterator(m_UniqueCorpseTargetInfo.end()));
+        m_UniqueCorpseTargetInfo.erase(itr, m_UniqueCorpseTargetInfo.end());
 
-    DoProcessTargetContainer(delayedCorpseTargets);
+        DoProcessTargetContainer(delayedCorpseTargets);
     }
 
     FinishTargetProcessing();
@@ -3885,10 +3842,7 @@ void Spell::_handle_finish_phase()
         Unit::ProcSkillsAndAuras(m_originalCaster, nullptr, procAttacker, PROC_FLAG_NONE, PROC_SPELL_TYPE_MASK_ALL, PROC_SPELL_PHASE_FINISH, m_hitMask, this, nullptr, nullptr);
 }
 
-void Spell::SendSpellCooldown()
-{
-    m_caster->GetSpellHistory()->HandleCooldowns(m_spellInfo, m_CastItem, this);
-}
+void Spell::SendSpellCooldown() { m_caster->GetSpellHistory()->HandleCooldowns(m_spellInfo, m_CastItem, this); }
 
 void Spell::update(uint32 difftime)
 {
@@ -5299,7 +5253,7 @@ void Spell::HandleThreatSpells()
     threat /= m_UniqueTargetInfo.size();
 
     for (auto ihit = m_UniqueTargetInfo.begin(); ihit != m_UniqueTargetInfo.end(); ++ihit)
-{
+    {
         float threatToAdd = threat;
         if (ihit->MissCondition != SPELL_MISS_NONE)
             threatToAdd = 0.0f;
@@ -6498,30 +6452,15 @@ bool Spell::CheckSpellCancelsCharm(uint32* param1) const
     return CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_CHARM, param1) && CheckSpellCancelsAuraEffect(SPELL_AURA_AOE_CHARM, param1) && CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_POSSESS, param1);
 }
 
-bool Spell::CheckSpellCancelsStun(uint32* param1) const
-{
-    return CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_STUN, param1) && CheckSpellCancelsAuraEffect(SPELL_AURA_STRANGULATE, param1);
-}
+bool Spell::CheckSpellCancelsStun(uint32* param1) const { return CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_STUN, param1) && CheckSpellCancelsAuraEffect(SPELL_AURA_STRANGULATE, param1); }
 
-bool Spell::CheckSpellCancelsSilence(uint32* param1) const
-{
-    return CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_SILENCE, param1) && CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_PACIFY_SILENCE, param1);
-}
+bool Spell::CheckSpellCancelsSilence(uint32* param1) const { return CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_SILENCE, param1) && CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_PACIFY_SILENCE, param1); }
 
-bool Spell::CheckSpellCancelsPacify(uint32* param1) const
-{
-    return CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_PACIFY, param1) && CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_PACIFY_SILENCE, param1);
-}
+bool Spell::CheckSpellCancelsPacify(uint32* param1) const { return CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_PACIFY, param1) && CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_PACIFY_SILENCE, param1); }
 
-bool Spell::CheckSpellCancelsFear(uint32* param1) const
-{
-    return CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_FEAR, param1);
-}
+bool Spell::CheckSpellCancelsFear(uint32* param1) const { return CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_FEAR, param1); }
 
-bool Spell::CheckSpellCancelsConfuse(uint32* param1) const
-{
-    return CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_CONFUSE, param1);
-}
+bool Spell::CheckSpellCancelsConfuse(uint32* param1) const { return CheckSpellCancelsAuraEffect(SPELL_AURA_MOD_CONFUSE, param1); }
 
 SpellCastResult Spell::CheckArenaAndRatedBattlegroundCastRules() const
 {
@@ -6554,10 +6493,7 @@ SpellCastResult Spell::CheckArenaAndRatedBattlegroundCastRules() const
     return SPELL_CAST_OK;
 }
 
-int32 Spell::CalculateDamage(uint8 i, Unit const* target) const
-{
-    return m_caster->CalculateSpellDamage(target, m_spellInfo, i, &m_spellValue->EffectBasePoints[i]);
-}
+int32 Spell::CalculateDamage(uint8 i, Unit const* target) const { return m_caster->CalculateSpellDamage(target, m_spellInfo, i, &m_spellValue->EffectBasePoints[i]); }
 
 bool Spell::CanAutoCast(Unit* target)
 {
@@ -7480,15 +7416,9 @@ bool Spell::CheckEffectTarget(Unit const* target, uint32 eff, Position const* lo
     return true;
 }
 
-bool Spell::IsTriggered() const
-{
-    return (_triggeredCastFlags & TRIGGERED_FULL_MASK) != 0;
-}
+bool Spell::IsTriggered() const { return (_triggeredCastFlags & TRIGGERED_FULL_MASK) != 0; }
 
-bool Spell::IsIgnoringCooldowns() const
-{
-    return (_triggeredCastFlags & TRIGGERED_IGNORE_SPELL_AND_CATEGORY_CD) != 0;
-}
+bool Spell::IsIgnoringCooldowns() const { return (_triggeredCastFlags & TRIGGERED_IGNORE_SPELL_AND_CATEGORY_CD) != 0; }
 
 bool Spell::IsFocusDisabled() const
 {
@@ -7496,15 +7426,9 @@ bool Spell::IsFocusDisabled() const
             (m_spellInfo->IsChanneled() && !m_spellInfo->HasAttribute(SpellAttr1(SPELL_ATTR1_CHANNEL_TRACK_TARGET | SPELL_ATTR1_SELF_CHANNELED))));
 }
 
-bool Spell::IsProcDisabled() const
-{
-    return (_triggeredCastFlags & TRIGGERED_DISALLOW_PROC_EVENTS) != 0;
-}
+bool Spell::IsProcDisabled() const { return (_triggeredCastFlags & TRIGGERED_DISALLOW_PROC_EVENTS) != 0; }
 
-bool Spell::IsChannelActive() const
-{
-    return m_caster->GetUInt32Value(UNIT_CHANNEL_SPELL) != 0;
-}
+bool Spell::IsChannelActive() const { return m_caster->GetUInt32Value(UNIT_CHANNEL_SPELL) != 0; }
 
 bool Spell::IsAutoActionResetSpell() const
 {
@@ -7529,10 +7453,7 @@ bool Spell::IsAutoActionResetSpell() const
     return true;
 }
 
-bool Spell::IsPositive() const
-{
-    return m_spellInfo->IsPositive() && (!m_triggeredByAuraSpell || m_triggeredByAuraSpell->IsPositive());
-}
+bool Spell::IsPositive() const { return m_spellInfo->IsPositive() && (!m_triggeredByAuraSpell || m_triggeredByAuraSpell->IsPositive()); }
 
 bool Spell::IsNeedSendToClient() const
 {
@@ -7540,10 +7461,7 @@ bool Spell::IsNeedSendToClient() const
            (!m_triggeredByAuraSpell && !IsTriggered());
 }
 
-SpellEvent::SpellEvent(Spell* spell) : BasicEvent()
-{
-    m_Spell = spell;
-}
+SpellEvent::SpellEvent(Spell* spell) : BasicEvent() { m_Spell = spell; }
 
 SpellEvent::~SpellEvent()
 {
@@ -7657,10 +7575,7 @@ void SpellEvent::Abort(uint64 /*e_time*/)
         m_Spell->cancel();
 }
 
-bool SpellEvent::IsDeletable() const
-{
-    return m_Spell->IsDeletable();
-}
+bool SpellEvent::IsDeletable() const { return m_Spell->IsDeletable(); }
 
 bool Spell::IsValidDeadOrAliveTarget(Unit const* target) const
 {
@@ -7906,15 +7821,9 @@ void Spell::SetSpellValue(SpellValueMod mod, int32 value)
     }
 }
 
-void Spell::PrepareTargetProcessing()
-{
-    AssertEffectExecuteData();
-}
+void Spell::PrepareTargetProcessing() { AssertEffectExecuteData(); }
 
-void Spell::FinishTargetProcessing()
-{
-    SendLogExecute();
-}
+void Spell::FinishTargetProcessing() { SendLogExecute(); }
 
 void Spell::InitEffectExecuteData(uint8 effIndex)
 {
@@ -8289,194 +8198,191 @@ void Spell::CancelGlobalCooldown()
 namespace Firelands
 {
 
-WorldObjectSpellTargetCheck::WorldObjectSpellTargetCheck(Unit* caster, Unit* referer, SpellInfo const* spellInfo, SpellTargetCheckTypes selectionType, ConditionContainer* condList)
-    : _caster(caster), _referer(referer), _spellInfo(spellInfo), _targetSelectionType(selectionType), _condList(condList)
-{
-    if (condList)
-        _condSrcInfo = new ConditionSourceInfo(nullptr, caster);
-    else
-        _condSrcInfo = nullptr;
-}
-
-WorldObjectSpellTargetCheck::~WorldObjectSpellTargetCheck()
-{
-    delete _condSrcInfo;
-}
-
-bool WorldObjectSpellTargetCheck::operator()(WorldObject* target)
-{
-    if (_spellInfo->CheckTarget(_caster, target, true) != SPELL_CAST_OK)
-        return false;
-    Unit* unitTarget = target->ToUnit();
-    if (Corpse* corpse = target->ToCorpse())
+    WorldObjectSpellTargetCheck::WorldObjectSpellTargetCheck(Unit* caster, Unit* referer, SpellInfo const* spellInfo, SpellTargetCheckTypes selectionType, ConditionContainer* condList)
+        : _caster(caster), _referer(referer), _spellInfo(spellInfo), _targetSelectionType(selectionType), _condList(condList)
     {
-        // use ofter for party/assistance checks
-        if (Player* owner = ObjectAccessor::FindPlayer(corpse->GetOwnerGUID()))
-            unitTarget = owner;
+        if (condList)
+            _condSrcInfo = new ConditionSourceInfo(nullptr, caster);
         else
-            return false;
+            _condSrcInfo = nullptr;
     }
-    if (unitTarget)
+
+    WorldObjectSpellTargetCheck::~WorldObjectSpellTargetCheck() { delete _condSrcInfo; }
+
+    bool WorldObjectSpellTargetCheck::operator()(WorldObject* target)
     {
-        switch (_targetSelectionType)
+        if (_spellInfo->CheckTarget(_caster, target, true) != SPELL_CAST_OK)
+            return false;
+        Unit* unitTarget = target->ToUnit();
+        if (Corpse* corpse = target->ToCorpse())
         {
-        case TARGET_CHECK_ENEMY:
-            if (unitTarget->IsTotem())
+            // use ofter for party/assistance checks
+            if (Player* owner = ObjectAccessor::FindPlayer(corpse->GetOwnerGUID()))
+                unitTarget = owner;
+            else
                 return false;
-            if (!target->IsCorpse() && !_caster->IsValidAttackTarget(unitTarget, _spellInfo, nullptr, false))
-                return false;
-            break;
-        case TARGET_CHECK_ALLY:
-            if (unitTarget->IsTotem())
-                return false;
-            if (!target->IsCorpse() && !_caster->IsValidAssistTarget(unitTarget, _spellInfo, false))
-                return false;
-            break;
-        case TARGET_CHECK_PARTY:
-            if (unitTarget->IsTotem())
-                return false;
-            if (!target->IsCorpse() && !_caster->IsValidAssistTarget(unitTarget, _spellInfo, false))
-                return false;
-            if (!_referer->IsInPartyWith(unitTarget))
-                return false;
-            break;
-        case TARGET_CHECK_RAID_CLASS:
-            if (_referer->getClass() != unitTarget->getClass())
-                return false;
-            [[fallthrough]];
-        case TARGET_CHECK_RAID:
-            if (unitTarget->IsTotem())
-                return false;
-            if (!target->IsCorpse() && !_caster->IsValidAssistTarget(unitTarget, _spellInfo, false))
-                return false;
-            if (!_referer->IsInRaidWith(unitTarget))
-                return false;
-            break;
-        case TARGET_CHECK_SUMMONED:
-            if (!unitTarget->IsSummon())
-                return false;
-            if (unitTarget->ToTempSummon()->GetSummonerGUID() != _caster->GetGUID())
-                return false;
-            break;
-        case TARGET_CHECK_THREAT:
-            if (_referer->GetThreatManager().GetThreat(unitTarget, true) <= 0.0f)
-                return false;
-            break;
-        case TARGET_CHECK_TAP:
-            if (_referer->GetTypeId() != TYPEID_UNIT || unitTarget->GetTypeId() != TYPEID_PLAYER)
-                return false;
-            if (!_referer->ToCreature()->isTappedBy(unitTarget->ToPlayer()))
-                return false;
-            break;
-        default:
-            break;
         }
-        // then check actual spell positivity to determine if the target is valid
-        // (negative spells may be targeted on allies)
-        if (_spellInfo->IsPositive())
+        if (unitTarget)
         {
-            if (!_caster->IsValidSpellAssistTarget(unitTarget, _spellInfo))
+            switch (_targetSelectionType)
+            {
+            case TARGET_CHECK_ENEMY:
+                if (unitTarget->IsTotem())
+                    return false;
+                if (!target->IsCorpse() && !_caster->IsValidAttackTarget(unitTarget, _spellInfo, nullptr, false))
+                    return false;
+                break;
+            case TARGET_CHECK_ALLY:
+                if (unitTarget->IsTotem())
+                    return false;
+                if (!target->IsCorpse() && !_caster->IsValidAssistTarget(unitTarget, _spellInfo, false))
+                    return false;
+                break;
+            case TARGET_CHECK_PARTY:
+                if (unitTarget->IsTotem())
+                    return false;
+                if (!target->IsCorpse() && !_caster->IsValidAssistTarget(unitTarget, _spellInfo, false))
+                    return false;
+                if (!_referer->IsInPartyWith(unitTarget))
+                    return false;
+                break;
+            case TARGET_CHECK_RAID_CLASS:
+                if (_referer->getClass() != unitTarget->getClass())
+                    return false;
+                [[fallthrough]];
+            case TARGET_CHECK_RAID:
+                if (unitTarget->IsTotem())
+                    return false;
+                if (!target->IsCorpse() && !_caster->IsValidAssistTarget(unitTarget, _spellInfo, false))
+                    return false;
+                if (!_referer->IsInRaidWith(unitTarget))
+                    return false;
+                break;
+            case TARGET_CHECK_SUMMONED:
+                if (!unitTarget->IsSummon())
+                    return false;
+                if (unitTarget->ToTempSummon()->GetSummonerGUID() != _caster->GetGUID())
+                    return false;
+                break;
+            case TARGET_CHECK_THREAT:
+                if (_referer->GetThreatManager().GetThreat(unitTarget, true) <= 0.0f)
+                    return false;
+                break;
+            case TARGET_CHECK_TAP:
+                if (_referer->GetTypeId() != TYPEID_UNIT || unitTarget->GetTypeId() != TYPEID_PLAYER)
+                    return false;
+                if (!_referer->ToCreature()->isTappedBy(unitTarget->ToPlayer()))
+                    return false;
+                break;
+            default:
+                break;
+            }
+            // then check actual spell positivity to determine if the target is valid
+            // (negative spells may be targeted on allies)
+            if (_spellInfo->IsPositive())
+            {
+                if (!_caster->IsValidSpellAssistTarget(unitTarget, _spellInfo))
+                    return false;
+            }
+            else
+            {
+                if (!_caster->IsValidSpellAttackTarget(unitTarget, _spellInfo))
+                    return false;
+            }
+        }
+        if (!_condSrcInfo)
+            return true;
+        _condSrcInfo->mConditionTargets[0] = target;
+        return sConditionMgr->IsObjectMeetToConditions(*_condSrcInfo, *_condList);
+    }
+
+    WorldObjectSpellNearbyTargetCheck::WorldObjectSpellNearbyTargetCheck(float range, Unit* caster, SpellInfo const* spellInfo, SpellTargetCheckTypes selectionType, ConditionContainer* condList)
+        : WorldObjectSpellTargetCheck(caster, caster, spellInfo, selectionType, condList), _range(range), _position(caster)
+    {
+    }
+
+    bool WorldObjectSpellNearbyTargetCheck::operator()(WorldObject* target)
+    {
+        float dist = target->GetDistance(*_position);
+        if (dist < _range && WorldObjectSpellTargetCheck::operator()(target))
+        {
+            _range = dist;
+            return true;
+        }
+        return false;
+    }
+
+    WorldObjectSpellAreaTargetCheck::WorldObjectSpellAreaTargetCheck(
+        float range, Position const* position, Unit* caster, Unit* referer, SpellInfo const* spellInfo, SpellTargetCheckTypes selectionType, ConditionContainer* condList)
+        : WorldObjectSpellTargetCheck(caster, referer, spellInfo, selectionType, condList), _range(range), _position(position)
+    {
+    }
+
+    bool WorldObjectSpellAreaTargetCheck::operator()(WorldObject* target)
+    {
+        if (target->ToGameObject())
+        {
+            // isInRange including the dimension of the GO
+            bool isInRange = target->ToGameObject()->IsInRange(_position->GetPositionX(), _position->GetPositionY(), _position->GetPositionZ(), _range);
+            if (!isInRange)
+                return false;
+        }
+        else if (target->ToUnit())
+        {
+            float hitboxSum = (_spellInfo->HasAttribute(SPELL_ATTR5_TREAT_AS_AREA_EFFECT) && _spellInfo->SpellFamilyName != SPELLFAMILY_GENERIC) ? target->ToUnit()->GetMeleeRange(_caster) : 0.f;
+            bool isInsideCylinder = target->IsWithinDist2d(_position, _range + hitboxSum) && std::abs(target->GetPositionZ() - _position->GetPositionZ()) <= (_range + hitboxSum);
+            if (!isInsideCylinder)
+                return false;
+        }
+
+        return WorldObjectSpellTargetCheck::operator()(target);
+    }
+
+    WorldObjectSpellConeTargetCheck::WorldObjectSpellConeTargetCheck(
+        Position const& coneSrc, float coneAngle, float range, Unit* caster, SpellInfo const* spellInfo, SpellTargetCheckTypes selectionType, ConditionContainer* condList)
+        : WorldObjectSpellAreaTargetCheck(range, caster, caster, caster, spellInfo, selectionType, condList), _coneSrc(coneSrc), _coneAngle(coneAngle)
+    {
+    }
+
+    bool WorldObjectSpellConeTargetCheck::operator()(WorldObject* target)
+    {
+        if (_spellInfo->HasAttribute(SPELL_ATTR0_CU_CONE_BACK))
+        {
+            if (_coneSrc.HasInArc(-std::abs(_coneAngle), target))
+                return false;
+        }
+        else if (_spellInfo->HasAttribute(SPELL_ATTR0_CU_CONE_LINE))
+        {
+            if (!_coneSrc.HasInLine(target, _caster->GetCombatReach(), 0.f))
                 return false;
         }
         else
         {
-            if (!_caster->IsValidSpellAttackTarget(unitTarget, _spellInfo))
-                return false;
+            if (!_caster->IsWithinBoundaryRadius(target->ToUnit()))
+                // ConeAngle > 0 -> select targets in front
+                // ConeAngle < 0 -> select targets in back
+                if (_coneSrc.HasInArc(_coneAngle, target) != G3D::fuzzyGe(_coneAngle, 0.f))
+                    return false;
         }
+        return WorldObjectSpellAreaTargetCheck::operator()(target);
     }
-    if (!_condSrcInfo)
-        return true;
-    _condSrcInfo->mConditionTargets[0] = target;
-    return sConditionMgr->IsObjectMeetToConditions(*_condSrcInfo, *_condList);
-}
 
-WorldObjectSpellNearbyTargetCheck::WorldObjectSpellNearbyTargetCheck(float range, Unit* caster, SpellInfo const* spellInfo, SpellTargetCheckTypes selectionType, ConditionContainer* condList)
-    : WorldObjectSpellTargetCheck(caster, caster, spellInfo, selectionType, condList), _range(range), _position(caster)
-{
-}
-
-bool WorldObjectSpellNearbyTargetCheck::operator()(WorldObject* target)
-{
-    float dist = target->GetDistance(*_position);
-    if (dist < _range && WorldObjectSpellTargetCheck::operator()(target))
+    WorldObjectSpellTrajTargetCheck::WorldObjectSpellTrajTargetCheck(
+        float range, Position const* position, Unit* caster, SpellInfo const* spellInfo, SpellTargetCheckTypes selectionType, ConditionContainer* condList)
+        : WorldObjectSpellTargetCheck(caster, caster, spellInfo, selectionType, condList), _range(range), _position(position)
     {
-        _range = dist;
-        return true;
     }
-    return false;
-}
 
-WorldObjectSpellAreaTargetCheck::WorldObjectSpellAreaTargetCheck(
-    float range, Position const* position, Unit* caster, Unit* referer, SpellInfo const* spellInfo, SpellTargetCheckTypes selectionType, ConditionContainer* condList)
-    : WorldObjectSpellTargetCheck(caster, referer, spellInfo, selectionType, condList), _range(range), _position(position)
-{
-}
-
-bool WorldObjectSpellAreaTargetCheck::operator()(WorldObject* target)
-{
-    if (target->ToGameObject())
+    bool WorldObjectSpellTrajTargetCheck::operator()(WorldObject* target)
     {
-        // isInRange including the dimension of the GO
-        bool isInRange = target->ToGameObject()->IsInRange(_position->GetPositionX(), _position->GetPositionY(), _position->GetPositionZ(), _range);
-        if (!isInRange)
+        // return all targets on missile trajectory (0 - size of a missile)
+        if (!_caster->HasInLine(target, target->GetCombatReach(), TRAJECTORY_MISSILE_SIZE))
             return false;
-    }
-    else if (target->ToUnit())
-    {
-        float hitboxSum = (_spellInfo->HasAttribute(SPELL_ATTR5_TREAT_AS_AREA_EFFECT) && _spellInfo->SpellFamilyName != SPELLFAMILY_GENERIC) ? target->ToUnit()->GetMeleeRange(_caster) : 0.f;
-        bool isInsideCylinder = target->IsWithinDist2d(_position, _range + hitboxSum) && std::abs(target->GetPositionZ() - _position->GetPositionZ()) <= (_range + hitboxSum);
-        if (!isInsideCylinder)
+
+        if (target->GetExactDist2d(_position) > _range)
             return false;
+
+        return WorldObjectSpellTargetCheck::operator()(target);
     }
-
-    return WorldObjectSpellTargetCheck::operator()(target);
-}
-
-WorldObjectSpellConeTargetCheck::WorldObjectSpellConeTargetCheck(
-    Position const& coneSrc, float coneAngle, float range, Unit* caster, SpellInfo const* spellInfo, SpellTargetCheckTypes selectionType, ConditionContainer* condList)
-    : WorldObjectSpellAreaTargetCheck(range, caster, caster, caster, spellInfo, selectionType, condList), _coneSrc(coneSrc), _coneAngle(coneAngle)
-{
-}
-
-bool WorldObjectSpellConeTargetCheck::operator()(WorldObject* target)
-{
-    if (_spellInfo->HasAttribute(SPELL_ATTR0_CU_CONE_BACK))
-    {
-        if (_coneSrc.HasInArc(-std::abs(_coneAngle), target))
-            return false;
-    }
-    else if (_spellInfo->HasAttribute(SPELL_ATTR0_CU_CONE_LINE))
-    {
-        if (!_coneSrc.HasInLine(target, _caster->GetCombatReach(), 0.f))
-            return false;
-    }
-    else
-    {
-        if (!_caster->IsWithinBoundaryRadius(target->ToUnit()))
-            // ConeAngle > 0 -> select targets in front
-            // ConeAngle < 0 -> select targets in back
-            if (_coneSrc.HasInArc(_coneAngle, target) != G3D::fuzzyGe(_coneAngle, 0.f))
-                return false;
-    }
-    return WorldObjectSpellAreaTargetCheck::operator()(target);
-}
-
-WorldObjectSpellTrajTargetCheck::WorldObjectSpellTrajTargetCheck(
-    float range, Position const* position, Unit* caster, SpellInfo const* spellInfo, SpellTargetCheckTypes selectionType, ConditionContainer* condList)
-    : WorldObjectSpellTargetCheck(caster, caster, spellInfo, selectionType, condList), _range(range), _position(position)
-{
-}
-
-bool WorldObjectSpellTrajTargetCheck::operator()(WorldObject* target)
-{
-    // return all targets on missile trajectory (0 - size of a missile)
-    if (!_caster->HasInLine(target, target->GetCombatReach(), TRAJECTORY_MISSILE_SIZE))
-        return false;
-
-    if (target->GetExactDist2d(_position) > _range)
-        return false;
-
-    return WorldObjectSpellTargetCheck::operator()(target);
-}
 
 } // namespace Firelands

--- a/src/server/game/Spells/Spell.cpp
+++ b/src/server/game/Spells/Spell.cpp
@@ -407,7 +407,10 @@ void SpellCastTargets::ModSrc(Position const& pos)
 
 void SpellCastTargets::RemoveSrc() { m_targetMask &= ~(TARGET_FLAG_SOURCE_LOCATION); }
 
-SpellDestination const* SpellCastTargets::GetDst() const { return &m_dst; }
+SpellDestination const* SpellCastTargets::GetDst() const
+{
+    return &m_dst;
+}
 
 WorldLocation const* SpellCastTargets::GetDstPos() const { return &m_dst._position; }
 

--- a/src/server/game/Spells/SpellInfo.h
+++ b/src/server/game/Spells/SpellInfo.h
@@ -68,8 +68,8 @@ enum SpellCastTargetFlags : uint32
     TARGET_FLAG_EXTRA_TARGETS = 0x00080000,   // uint32 counter, loop { vec3 - screen position (?), guid }, not used so far
     TARGET_FLAG_UNIT_PASSENGER = 0x00100000,  // guessed, used to validate target (if vehicle passenger)
 
-    TARGET_FLAG_UNIT_MASK = TARGET_FLAG_UNIT | TARGET_FLAG_UNIT_RAID | TARGET_FLAG_UNIT_PARTY | TARGET_FLAG_UNIT_ENEMY |
-                            TARGET_FLAG_UNIT_ALLY | TARGET_FLAG_UNIT_DEAD | TARGET_FLAG_UNIT_MINIPET | TARGET_FLAG_UNIT_PASSENGER,
+    TARGET_FLAG_UNIT_MASK = TARGET_FLAG_UNIT | TARGET_FLAG_UNIT_RAID | TARGET_FLAG_UNIT_PARTY | TARGET_FLAG_UNIT_ENEMY | TARGET_FLAG_UNIT_ALLY | TARGET_FLAG_UNIT_DEAD | TARGET_FLAG_UNIT_MINIPET |
+                            TARGET_FLAG_UNIT_PASSENGER,
     TARGET_FLAG_GAMEOBJECT_MASK = TARGET_FLAG_GAMEOBJECT | TARGET_FLAG_GAMEOBJECT_ITEM,
     TARGET_FLAG_CORPSE_MASK = TARGET_FLAG_CORPSE_ALLY | TARGET_FLAG_CORPSE_ENEMY,
     TARGET_FLAG_ITEM_MASK = TARGET_FLAG_TRADE_ITEM | TARGET_FLAG_ITEM | TARGET_FLAG_GAMEOBJECT_ITEM
@@ -192,6 +192,7 @@ enum SpellCustomAttributes
     SPELL_ATTR0_CU_DIRECT_DAMAGE = 0x00000100,
     SPELL_ATTR0_CU_CHARGE = 0x00000200,
     SPELL_ATTR0_CU_PICKPOCKET = 0x00000400,
+    SPELL_ATTR0_CU_ROLLING_PERIODIC = 0x00000800,
     SPELL_ATTR0_CU_NEGATIVE_EFF0 = 0x00001000,
     SPELL_ATTR0_CU_NEGATIVE_EFF1 = 0x00002000,
     SPELL_ATTR0_CU_NEGATIVE_EFF2 = 0x00004000,
@@ -279,9 +280,8 @@ class FC_GAME_API SpellEffectInfo
     } Scaling;
 
     SpellEffectInfo()
-        : _spellInfo(nullptr), _effIndex(0), Effect(0), ApplyAuraName(0), AuraPeriod(0), DieSides(0), RealPointsPerLevel(0.f),
-          BasePoints(0), PointsPerComboPoint(0), Amplitude(0.f), DamageMultiplier(0.f), BonusMultiplier(0.f), MiscValue(0),
-          MiscValueB(0), Mechanic(MECHANIC_NONE), RadiusEntry(nullptr), MaxRadiusEntry(nullptr), ChainTarget(0), ItemType(0),
+        : _spellInfo(nullptr), _effIndex(0), Effect(0), ApplyAuraName(0), AuraPeriod(0), DieSides(0), RealPointsPerLevel(0.f), BasePoints(0), PointsPerComboPoint(0), Amplitude(0.f),
+          DamageMultiplier(0.f), BonusMultiplier(0.f), MiscValue(0), MiscValueB(0), Mechanic(MECHANIC_NONE), RadiusEntry(nullptr), MaxRadiusEntry(nullptr), ChainTarget(0), ItemType(0),
           TriggerSpell(0), ImplicitTargetConditions(nullptr), Scaling()
     {
     }
@@ -596,8 +596,7 @@ class FC_GAME_API SpellInfo
     uint32 GetRecoveryTime() const;
 
     int32 CalcPowerCost(Unit const* caster, SpellSchoolMask schoolMask, Spell* spell = nullptr) const;
-    float GetSpellScalingMultiplier(
-        Unit const* caster, SpellScalingEntry const* scalingEntry, bool isPowerCostRelated = false) const;
+    float GetSpellScalingMultiplier(Unit const* caster, SpellScalingEntry const* scalingEntry, bool isPowerCostRelated = false) const;
 
     bool IsRanked() const;
     uint8 GetRank() const;

--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -32,6 +32,7 @@
 #include "SpellAuraDefines.h"
 #include "SpellInfo.h"
 #include <G3D/g3dmath.h>
+#include "Containers.h"
 
 bool IsPrimaryProfessionSkill(uint32 skill)
 {
@@ -55,14 +56,9 @@ bool IsPartOfSkillLine(uint32 skillId, uint32 spellId)
     return false;
 }
 
-SpellMgr::SpellMgr()
-{
-}
+SpellMgr::SpellMgr() {}
 
-SpellMgr::~SpellMgr()
-{
-    UnloadSpellInfoStore();
-}
+SpellMgr::~SpellMgr() { UnloadSpellInfoStore(); }
 
 SpellMgr* SpellMgr::instance()
 {
@@ -298,15 +294,9 @@ uint32 SpellMgr::GetSpellWithRank(uint32 spell_id, uint32 rank, bool strict) con
     return spell_id;
 }
 
-Firelands::IteratorPair<SpellRequiredMap::const_iterator> SpellMgr::GetSpellsRequiredForSpellBounds(uint32 spell_id) const
-{
-    return Firelands::Containers::MapEqualRange(mSpellReq, spell_id);
-}
+Firelands::IteratorPair<SpellRequiredMap::const_iterator> SpellMgr::GetSpellsRequiredForSpellBounds(uint32 spell_id) const { return Firelands::Containers::MapEqualRange(mSpellReq, spell_id); }
 
-SpellsRequiringSpellMapBounds SpellMgr::GetSpellsRequiringSpellBounds(uint32 spell_id) const
-{
-    return mSpellsReqSpell.equal_range(spell_id);
-}
+SpellsRequiringSpellMapBounds SpellMgr::GetSpellsRequiringSpellBounds(uint32 spell_id) const { return mSpellsReqSpell.equal_range(spell_id); }
 
 bool SpellMgr::IsSpellRequiringSpell(uint32 spellid, uint32 req_spellid) const
 {
@@ -328,15 +318,9 @@ SpellLearnSkillNode const* SpellMgr::GetSpellLearnSkill(uint32 spell_id) const
         return nullptr;
 }
 
-SpellLearnSpellMapBounds SpellMgr::GetSpellLearnSpellMapBounds(uint32 spell_id) const
-{
-    return mSpellLearnSpells.equal_range(spell_id);
-}
+SpellLearnSpellMapBounds SpellMgr::GetSpellLearnSpellMapBounds(uint32 spell_id) const { return mSpellLearnSpells.equal_range(spell_id); }
 
-bool SpellMgr::IsSpellLearnSpell(uint32 spell_id) const
-{
-    return mSpellLearnSpells.find(spell_id) != mSpellLearnSpells.end();
-}
+bool SpellMgr::IsSpellLearnSpell(uint32 spell_id) const { return mSpellLearnSpells.find(spell_id) != mSpellLearnSpells.end(); }
 
 bool SpellMgr::IsSpellLearnToSpell(uint32 spell_id1, uint32 spell_id2) const
 {
@@ -372,10 +356,7 @@ bool SpellMgr::IsSpellMemberOfSpellGroup(uint32 spellid, SpellGroup groupid) con
     return false;
 }
 
-SpellGroupSpellMapBounds SpellMgr::GetSpellGroupSpellMapBounds(SpellGroup group_id) const
-{
-    return mSpellGroupSpell.equal_range(group_id);
-}
+SpellGroupSpellMapBounds SpellMgr::GetSpellGroupSpellMapBounds(SpellGroup group_id) const { return mSpellGroupSpell.equal_range(group_id); }
 
 void SpellMgr::GetSetOfSpellsInSpellGroup(SpellGroup group_id, std::set<uint32>& foundSpells) const
 {
@@ -599,10 +580,7 @@ SpellThreatEntry const* SpellMgr::GetSpellThreatEntry(uint32 spellID) const
     return nullptr;
 }
 
-SkillLineAbilityMapBounds SpellMgr::GetSkillLineAbilityMapBounds(uint32 spell_id) const
-{
-    return mSkillLineAbilityMap.equal_range(spell_id);
-}
+SkillLineAbilityMapBounds SpellMgr::GetSkillLineAbilityMapBounds(uint32 spell_id) const { return mSkillLineAbilityMap.equal_range(spell_id); }
 
 PetAura const* SpellMgr::GetPetAura(uint32 spell_id, uint8 eff) const
 {
@@ -629,11 +607,7 @@ bool SpellMgr::IsArenaAllowedEnchancment(uint32 ench_id) const
     return false;
 }
 
-const std::vector<int32>* SpellMgr::GetSpellLinked(int32 spell_id) const
-{
-    SpellLinkedMap::const_iterator itr = mSpellLinkedMap.find(spell_id);
-    return itr != mSpellLinkedMap.end() ? &(itr->second) : nullptr;
-}
+std::vector<int32> const* SpellMgr::GetSpellLinked(int32 spell_id) const { return Firelands::Containers::MapGetValuePtr(mSpellLinkedMap, spell_id); }
 
 PetLevelupSpellSet const* SpellMgr::GetPetLevelupSpellList(uint32 petFamily) const
 {
@@ -652,30 +626,15 @@ PetDefaultSpellsEntry const* SpellMgr::GetPetDefaultSpellsEntry(int32 id) const
     return nullptr;
 }
 
-SpellAreaMapBounds SpellMgr::GetSpellAreaMapBounds(uint32 spell_id) const
-{
-    return mSpellAreaMap.equal_range(spell_id);
-}
+SpellAreaMapBounds SpellMgr::GetSpellAreaMapBounds(uint32 spell_id) const { return mSpellAreaMap.equal_range(spell_id); }
 
-SpellAreaForQuestMapBounds SpellMgr::GetSpellAreaForQuestMapBounds(uint32 quest_id) const
-{
-    return mSpellAreaForQuestMap.equal_range(quest_id);
-}
+SpellAreaForQuestMapBounds SpellMgr::GetSpellAreaForQuestMapBounds(uint32 quest_id) const { return mSpellAreaForQuestMap.equal_range(quest_id); }
 
-SpellAreaForQuestMapBounds SpellMgr::GetSpellAreaForQuestEndMapBounds(uint32 quest_id) const
-{
-    return mSpellAreaForQuestEndMap.equal_range(quest_id);
-}
+SpellAreaForQuestMapBounds SpellMgr::GetSpellAreaForQuestEndMapBounds(uint32 quest_id) const { return mSpellAreaForQuestEndMap.equal_range(quest_id); }
 
-SpellAreaForAuraMapBounds SpellMgr::GetSpellAreaForAuraMapBounds(uint32 spell_id) const
-{
-    return mSpellAreaForAuraMap.equal_range(spell_id);
-}
+SpellAreaForAuraMapBounds SpellMgr::GetSpellAreaForAuraMapBounds(uint32 spell_id) const { return mSpellAreaForAuraMap.equal_range(spell_id); }
 
-SpellAreaForAreaMapBounds SpellMgr::GetSpellAreaForAreaMapBounds(uint32 area_id) const
-{
-    return mSpellAreaForAreaMap.equal_range(area_id);
-}
+SpellAreaForAreaMapBounds SpellMgr::GetSpellAreaForAreaMapBounds(uint32 area_id) const { return mSpellAreaForAreaMap.equal_range(area_id); }
 
 bool SpellArea::IsFitToRequirements(Player const* player, uint32 newZone, uint32 newArea) const
 {
@@ -2708,18 +2667,18 @@ void SpellMgr::LoadSpellInfoCustomAttributes()
 
             switch (spellInfo->Effects[j].Effect)
             {
-             case SPELL_EFFECT_SCHOOL_DAMAGE:
-             case SPELL_EFFECT_HEALTH_LEECH:
-             case SPELL_EFFECT_HEAL:
-             case SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL:
-             case SPELL_EFFECT_WEAPON_PERCENT_DAMAGE:
-             case SPELL_EFFECT_WEAPON_DAMAGE:
-             case SPELL_EFFECT_POWER_BURN:
-             case SPELL_EFFECT_HEAL_MECHANICAL:
-             case SPELL_EFFECT_NORMALIZED_WEAPON_DMG:
-             case SPELL_EFFECT_HEAL_PCT:
-             spellInfo->AttributesCu |= SPELL_ATTR0_CU_CAN_CRIT;
-             break;
+            case SPELL_EFFECT_SCHOOL_DAMAGE:
+            case SPELL_EFFECT_HEALTH_LEECH:
+            case SPELL_EFFECT_HEAL:
+            case SPELL_EFFECT_WEAPON_DAMAGE_NOSCHOOL:
+            case SPELL_EFFECT_WEAPON_PERCENT_DAMAGE:
+            case SPELL_EFFECT_WEAPON_DAMAGE:
+            case SPELL_EFFECT_POWER_BURN:
+            case SPELL_EFFECT_HEAL_MECHANICAL:
+            case SPELL_EFFECT_NORMALIZED_WEAPON_DMG:
+            case SPELL_EFFECT_HEAL_PCT:
+                spellInfo->AttributesCu |= SPELL_ATTR0_CU_CAN_CRIT;
+                break;
             }
             switch (spellInfo->Effects[j].Effect)
             {

--- a/src/server/game/Spells/SpellMgr.h
+++ b/src/server/game/Spells/SpellMgr.h
@@ -43,13 +43,13 @@ struct SkillLineAbilityEntry;
 enum SpellCategories
 {
     SPELLCATEGORY_HEALTH_MANA_POTIONS = 4,
-    SPELLCATEGORY_DEVOUR_MAGIC        = 12,
-    SPELLCATEGORY_JUDGEMENT           = 1210,               // Judgement (seal trigger)
-    SPELLCATEGORY_FOOD                = 11,
-    SPELLCATEGORY_DRINK               = 59
+    SPELLCATEGORY_DEVOUR_MAGIC = 12,
+    SPELLCATEGORY_JUDGEMENT = 1210, // Judgement (seal trigger)
+    SPELLCATEGORY_FOOD = 11,
+    SPELLCATEGORY_DRINK = 59
 };
 
-//SpellFamilyFlags
+// SpellFamilyFlags
 enum SpellFamilyFlag
 {
     // SPELLFAMILYFLAG  = SpellFamilyFlags[0]
@@ -57,215 +57,194 @@ enum SpellFamilyFlag
     // SPELLFAMILYFLAG2 = SpellFamilyFlags[2]
 
     // Rogue
-    SPELLFAMILYFLAG0_ROGUE_VANISH               = 0x00000800,
-    SPELLFAMILYFLAG0_ROGUE_VAN_SPRINT           = 0x00000840, // Vanish, Sprint
-    SPELLFAMILYFLAG1_ROGUE_SHADOWSTEP           = 0x00000200, // Shadowstep
-    SPELLFAMILYFLAG0_ROGUE_KICK                 = 0x00000010, // Kick
+    SPELLFAMILYFLAG0_ROGUE_VANISH = 0x00000800,
+    SPELLFAMILYFLAG0_ROGUE_VAN_SPRINT = 0x00000840,           // Vanish, Sprint
+    SPELLFAMILYFLAG1_ROGUE_SHADOWSTEP = 0x00000200,           // Shadowstep
+    SPELLFAMILYFLAG0_ROGUE_KICK = 0x00000010,                 // Kick
     SPELLFAMILYFLAG1_ROGUE_DISMANTLE_SMOKE_BOMB = 0x80100000, // Dismantle, Smoke Bomb
 
     // Warrior
-    SPELLFAMILYFLAG_WARRIOR_CHARGE              = 0x00000001,
-    SPELLFAMILYFLAG_WARRIOR_SLAM                = 0x00200000,
-    SPELLFAMILYFLAG_WARRIOR_EXECUTE             = 0x20000000,
-    SPELLFAMILYFLAG_WARRIOR_CONCUSSION_BLOW     = 0x04000000,
+    SPELLFAMILYFLAG_WARRIOR_CHARGE = 0x00000001,
+    SPELLFAMILYFLAG_WARRIOR_SLAM = 0x00200000,
+    SPELLFAMILYFLAG_WARRIOR_EXECUTE = 0x20000000,
+    SPELLFAMILYFLAG_WARRIOR_CONCUSSION_BLOW = 0x04000000,
 
     // Warlock
-    SPELLFAMILYFLAG_WARLOCK_LIFETAP             = 0x00040000,
+    SPELLFAMILYFLAG_WARLOCK_LIFETAP = 0x00040000,
 
     // Druid
-    SPELLFAMILYFLAG2_DRUID_STARFALL             = 0x00000100,
+    SPELLFAMILYFLAG2_DRUID_STARFALL = 0x00000100,
 
     // Paladin
-    SPELLFAMILYFLAG1_PALADIN_DIVINESTORM        = 0x00020000,
+    SPELLFAMILYFLAG1_PALADIN_DIVINESTORM = 0x00020000,
 
     // Shaman
-    SPELLFAMILYFLAG_SHAMAN_FROST_SHOCK          = 0x80000000,
-    SPELLFAMILYFLAG_SHAMAN_HEALING_STREAM       = 0x00002000,
-    SPELLFAMILYFLAG_SHAMAN_MANA_SPRING          = 0x00004000,
-    SPELLFAMILYFLAG2_SHAMAN_LAVA_LASH           = 0x00000004,
-    SPELLFAMILYFLAG_SHAMAN_FIRE_NOVA            = 0x28000000,
+    SPELLFAMILYFLAG_SHAMAN_FROST_SHOCK = 0x80000000,
+    SPELLFAMILYFLAG_SHAMAN_HEALING_STREAM = 0x00002000,
+    SPELLFAMILYFLAG_SHAMAN_MANA_SPRING = 0x00004000,
+    SPELLFAMILYFLAG2_SHAMAN_LAVA_LASH = 0x00000004,
+    SPELLFAMILYFLAG_SHAMAN_FIRE_NOVA = 0x28000000,
 
     // Deathknight
-    SPELLFAMILYFLAG_DK_DEATH_STRIKE             = 0x00000010,
-    SPELLFAMILYFLAG_DK_DEATH_COIL               = 0x00002000,
+    SPELLFAMILYFLAG_DK_DEATH_STRIKE = 0x00000010,
+    SPELLFAMILYFLAG_DK_DEATH_COIL = 0x00002000,
 
     /// @todo Figure out a more accurate name for the following familyflag(s)
-    SPELLFAMILYFLAG_SHAMAN_TOTEM_EFFECTS        = 0x04000000  // Seems to be linked to most totems and some totem effects
+    SPELLFAMILYFLAG_SHAMAN_TOTEM_EFFECTS = 0x04000000 // Seems to be linked to most totems and some totem effects
 };
 
-
-#define SPELL_LINKED_MAX_SPELLS  200000
+#define SPELL_LINKED_MAX_SPELLS 200000
 
 enum SpellLinkedType
 {
-    SPELL_LINK_CAST     = 0,            // +: cast; -: remove
-    SPELL_LINK_HIT      = 1 * 200000,
-    SPELL_LINK_AURA     = 2 * 200000,   // +: aura; -: immune
-    SPELL_LINK_REMOVE   = 0
+    SPELL_LINK_CAST = 0, // +: cast; -: remove
+    SPELL_LINK_HIT = 1 * 200000,
+    SPELL_LINK_AURA = 2 * 200000, // +: aura; -: immune
+    SPELL_LINK_REMOVE = 0
 };
-
 
 // Spell proc event related declarations (accessed using SpellMgr functions)
 enum ProcFlags
 {
-    PROC_FLAG_NONE                              = 0x00000000,
+    PROC_FLAG_NONE = 0x00000000,
 
-    PROC_FLAG_HEARTBEAT                         = 0x00000001,    // 00 Killed by agressor - not sure about this flag
-    PROC_FLAG_KILL                              = 0x00000002,    // 01 Kill target (in most cases need XP/Honor reward)
+    PROC_FLAG_HEARTBEAT = 0x00000001, // 00 Killed by agressor - not sure about this flag
+    PROC_FLAG_KILL = 0x00000002,      // 01 Kill target (in most cases need XP/Honor reward)
 
-    PROC_FLAG_DEAL_MELEE_SWING                  = 0x00000004,    // 02 Done melee auto attack
-    PROC_FLAG_TAKE_MELEE_SWING                  = 0x00000008,    // 03 Taken melee auto attack
+    PROC_FLAG_DEAL_MELEE_SWING = 0x00000004, // 02 Done melee auto attack
+    PROC_FLAG_TAKE_MELEE_SWING = 0x00000008, // 03 Taken melee auto attack
 
-    PROC_FLAG_DEAL_MELEE_ABILITY                = 0x00000010,    // 04 Done attack by Spell that has dmg class melee
-    PROC_FLAG_TAKE_MELEE_ABILITY                = 0x00000020,    // 05 Taken attack by Spell that has dmg class melee
+    PROC_FLAG_DEAL_MELEE_ABILITY = 0x00000010, // 04 Done attack by Spell that has dmg class melee
+    PROC_FLAG_TAKE_MELEE_ABILITY = 0x00000020, // 05 Taken attack by Spell that has dmg class melee
 
-    PROC_FLAG_DEAL_RANGED_ATTACK                = 0x00000040,    // 06 Done ranged auto attack
-    PROC_FLAG_TAKE_RANGED_ATTACK                = 0x00000080,    // 07 Taken ranged auto attack
+    PROC_FLAG_DEAL_RANGED_ATTACK = 0x00000040, // 06 Done ranged auto attack
+    PROC_FLAG_TAKE_RANGED_ATTACK = 0x00000080, // 07 Taken ranged auto attack
 
-    PROC_FLAG_DEAL_RANGED_ABILITY               = 0x00000100,    // 08 Done attack by Spell that has dmg class ranged
-    PROC_FLAG_TAKE_RANGED_ABILITY               = 0x00000200,    // 09 Taken attack by Spell that has dmg class ranged
+    PROC_FLAG_DEAL_RANGED_ABILITY = 0x00000100, // 08 Done attack by Spell that has dmg class ranged
+    PROC_FLAG_TAKE_RANGED_ABILITY = 0x00000200, // 09 Taken attack by Spell that has dmg class ranged
 
-    PROC_FLAG_DEAL_HELPFUL_ABILITY              = 0x00000400,    // 10 Done positive spell that has dmg class none
-    PROC_FLAG_TAKE_HELPFUL_ABILITY              = 0x00000800,    // 11 Taken positive spell that has dmg class none
+    PROC_FLAG_DEAL_HELPFUL_ABILITY = 0x00000400, // 10 Done positive spell that has dmg class none
+    PROC_FLAG_TAKE_HELPFUL_ABILITY = 0x00000800, // 11 Taken positive spell that has dmg class none
 
-    PROC_FLAG_DEAL_HARMFUL_ABILITY              = 0x00001000,    // 12 Done negative spell that has dmg class none
-    PROC_FLAG_TAKE_HARMFUL_ABILITY              = 0x00002000,    // 13 Taken negative spell that has dmg class none
+    PROC_FLAG_DEAL_HARMFUL_ABILITY = 0x00001000, // 12 Done negative spell that has dmg class none
+    PROC_FLAG_TAKE_HARMFUL_ABILITY = 0x00002000, // 13 Taken negative spell that has dmg class none
 
-    PROC_FLAG_DEAL_HELPFUL_SPELL                = 0x00004000,    // 14 Done positive spell that has dmg class magic
-    PROC_FLAG_TAKE_HELPFUL_SPELL                = 0x00008000,    // 15 Taken positive spell that has dmg class magic
+    PROC_FLAG_DEAL_HELPFUL_SPELL = 0x00004000, // 14 Done positive spell that has dmg class magic
+    PROC_FLAG_TAKE_HELPFUL_SPELL = 0x00008000, // 15 Taken positive spell that has dmg class magic
 
-    PROC_FLAG_DEAL_HARMFUL_SPELL                = 0x00010000,    // 16 Done negative spell that has dmg class magic
-    PROC_FLAG_TAKE_HARMFUL_SPELL                = 0x00020000,    // 17 Taken negative spell that has dmg class magic
+    PROC_FLAG_DEAL_HARMFUL_SPELL = 0x00010000, // 16 Done negative spell that has dmg class magic
+    PROC_FLAG_TAKE_HARMFUL_SPELL = 0x00020000, // 17 Taken negative spell that has dmg class magic
 
-    PROC_FLAG_DEAL_PERIODIC                     = 0x00040000,    // 18 Successful do periodic (damage/heal)
-    PROC_FLAG_TAKE_PERIODIC                     = 0x00080000,    // 19 Taken spell periodic (damage/heal)
+    PROC_FLAG_DEAL_PERIODIC = 0x00040000, // 18 Successful do periodic (damage/heal)
+    PROC_FLAG_TAKE_PERIODIC = 0x00080000, // 19 Taken spell periodic (damage/heal)
 
-    PROC_FLAG_TAKE_ANY_DAMAGE                   = 0x00100000,    // 20 Taken any damage
+    PROC_FLAG_TAKE_ANY_DAMAGE = 0x00100000, // 20 Taken any damage
 
-    PROC_FLAG_TRAP_ACTIVATION                   = 0x00200000,    // 21 On trap activation (possibly needs name change to ON_GAMEOBJECT_CAST or USE)
+    PROC_FLAG_TRAP_ACTIVATION = 0x00200000, // 21 On trap activation (possibly needs name change to ON_GAMEOBJECT_CAST or USE)
 
-    PROC_FLAG_MAIN_HAND_WEAPON_SWING            = 0x00400000,    // 22 Done main-hand melee attacks (spell and autoattack)
-    PROC_FLAG_OFF_HAND_WEAPON_SWING             = 0x00800000,    // 23 Done off-hand melee attacks (spell and autoattack)
+    PROC_FLAG_MAIN_HAND_WEAPON_SWING = 0x00400000, // 22 Done main-hand melee attacks (spell and autoattack)
+    PROC_FLAG_OFF_HAND_WEAPON_SWING = 0x00800000,  // 23 Done off-hand melee attacks (spell and autoattack)
 
-    PROC_FLAG_DEATH                             = 0x01000000,    // 24 Died in any way
+    PROC_FLAG_DEATH = 0x01000000, // 24 Died in any way
 
-    PROC_FLAG_JUMP                              = 0x02000000,    // 25 Jumped
+    PROC_FLAG_JUMP = 0x02000000, // 25 Jumped
 
-    PROC_FLAG_PROC_CLONE_SPELL                  = 0x04000000,    // 26 Proc Clone Spell
+    PROC_FLAG_PROC_CLONE_SPELL = 0x04000000, // 26 Proc Clone Spell
 
-    PROC_FLAG_ENTER_COMBAT                      = 0x08000000,    // 27 Entered combat
+    PROC_FLAG_ENTER_COMBAT = 0x08000000, // 27 Entered combat
 
     // flag masks
-    AUTO_ATTACK_PROC_FLAG_MASK                  = PROC_FLAG_DEAL_MELEE_SWING | PROC_FLAG_TAKE_MELEE_SWING
-                                                | PROC_FLAG_DEAL_RANGED_ATTACK | PROC_FLAG_TAKE_RANGED_ATTACK,
+    AUTO_ATTACK_PROC_FLAG_MASK = PROC_FLAG_DEAL_MELEE_SWING | PROC_FLAG_TAKE_MELEE_SWING | PROC_FLAG_DEAL_RANGED_ATTACK | PROC_FLAG_TAKE_RANGED_ATTACK,
 
-    MELEE_PROC_FLAG_MASK                        = PROC_FLAG_DEAL_MELEE_SWING | PROC_FLAG_TAKE_MELEE_SWING
-                                                | PROC_FLAG_DEAL_MELEE_ABILITY | PROC_FLAG_TAKE_MELEE_ABILITY
-                                                | PROC_FLAG_MAIN_HAND_WEAPON_SWING | PROC_FLAG_OFF_HAND_WEAPON_SWING,
+    MELEE_PROC_FLAG_MASK =
+        PROC_FLAG_DEAL_MELEE_SWING | PROC_FLAG_TAKE_MELEE_SWING | PROC_FLAG_DEAL_MELEE_ABILITY | PROC_FLAG_TAKE_MELEE_ABILITY | PROC_FLAG_MAIN_HAND_WEAPON_SWING | PROC_FLAG_OFF_HAND_WEAPON_SWING,
 
-    RANGED_PROC_FLAG_MASK                       = PROC_FLAG_DEAL_RANGED_ATTACK | PROC_FLAG_TAKE_RANGED_ATTACK
-                                                | PROC_FLAG_DEAL_RANGED_ABILITY | PROC_FLAG_TAKE_RANGED_ABILITY,
+    RANGED_PROC_FLAG_MASK = PROC_FLAG_DEAL_RANGED_ATTACK | PROC_FLAG_TAKE_RANGED_ATTACK | PROC_FLAG_DEAL_RANGED_ABILITY | PROC_FLAG_TAKE_RANGED_ABILITY,
 
-    SPELL_PROC_FLAG_MASK                        = PROC_FLAG_DEAL_MELEE_ABILITY | PROC_FLAG_TAKE_MELEE_ABILITY
-                                                | PROC_FLAG_DEAL_RANGED_ATTACK | PROC_FLAG_TAKE_RANGED_ATTACK
-                                                | PROC_FLAG_DEAL_RANGED_ABILITY | PROC_FLAG_TAKE_RANGED_ABILITY
-                                                | PROC_FLAG_DEAL_HELPFUL_ABILITY | PROC_FLAG_TAKE_HELPFUL_ABILITY
-                                                | PROC_FLAG_DEAL_HARMFUL_ABILITY | PROC_FLAG_TAKE_HARMFUL_ABILITY
-                                                | PROC_FLAG_DEAL_HELPFUL_SPELL | PROC_FLAG_TAKE_HELPFUL_SPELL
-                                                | PROC_FLAG_DEAL_HARMFUL_SPELL | PROC_FLAG_TAKE_HARMFUL_SPELL
-                                                | PROC_FLAG_DEAL_PERIODIC | PROC_FLAG_TAKE_PERIODIC
-                                                | PROC_FLAG_TRAP_ACTIVATION,
+    SPELL_PROC_FLAG_MASK = PROC_FLAG_DEAL_MELEE_ABILITY | PROC_FLAG_TAKE_MELEE_ABILITY | PROC_FLAG_DEAL_RANGED_ATTACK | PROC_FLAG_TAKE_RANGED_ATTACK | PROC_FLAG_DEAL_RANGED_ABILITY |
+                           PROC_FLAG_TAKE_RANGED_ABILITY | PROC_FLAG_DEAL_HELPFUL_ABILITY | PROC_FLAG_TAKE_HELPFUL_ABILITY | PROC_FLAG_DEAL_HARMFUL_ABILITY | PROC_FLAG_TAKE_HARMFUL_ABILITY |
+                           PROC_FLAG_DEAL_HELPFUL_SPELL | PROC_FLAG_TAKE_HELPFUL_SPELL | PROC_FLAG_DEAL_HARMFUL_SPELL | PROC_FLAG_TAKE_HARMFUL_SPELL | PROC_FLAG_DEAL_PERIODIC |
+                           PROC_FLAG_TAKE_PERIODIC | PROC_FLAG_TRAP_ACTIVATION,
 
-    DONE_HIT_PROC_FLAG_MASK                     = PROC_FLAG_DEAL_MELEE_SWING | PROC_FLAG_DEAL_RANGED_ATTACK
-                                                | PROC_FLAG_DEAL_MELEE_ABILITY | PROC_FLAG_DEAL_RANGED_ABILITY
-                                                | PROC_FLAG_DEAL_HELPFUL_ABILITY | PROC_FLAG_DEAL_HARMFUL_ABILITY
-                                                | PROC_FLAG_DEAL_HELPFUL_SPELL | PROC_FLAG_DEAL_HARMFUL_SPELL
-                                                | PROC_FLAG_DEAL_PERIODIC | PROC_FLAG_TRAP_ACTIVATION
-                                                | PROC_FLAG_MAIN_HAND_WEAPON_SWING | PROC_FLAG_OFF_HAND_WEAPON_SWING,
+    DONE_HIT_PROC_FLAG_MASK = PROC_FLAG_DEAL_MELEE_SWING | PROC_FLAG_DEAL_RANGED_ATTACK | PROC_FLAG_DEAL_MELEE_ABILITY | PROC_FLAG_DEAL_RANGED_ABILITY | PROC_FLAG_DEAL_HELPFUL_ABILITY |
+                              PROC_FLAG_DEAL_HARMFUL_ABILITY | PROC_FLAG_DEAL_HELPFUL_SPELL | PROC_FLAG_DEAL_HARMFUL_SPELL | PROC_FLAG_DEAL_PERIODIC | PROC_FLAG_TRAP_ACTIVATION |
+                              PROC_FLAG_MAIN_HAND_WEAPON_SWING | PROC_FLAG_OFF_HAND_WEAPON_SWING,
 
-    TAKEN_HIT_PROC_FLAG_MASK                    = PROC_FLAG_TAKE_MELEE_SWING | PROC_FLAG_TAKE_RANGED_ATTACK
-                                                | PROC_FLAG_TAKE_MELEE_ABILITY | PROC_FLAG_TAKE_RANGED_ABILITY
-                                                | PROC_FLAG_TAKE_HELPFUL_ABILITY | PROC_FLAG_TAKE_HARMFUL_ABILITY
-                                                | PROC_FLAG_TAKE_HELPFUL_SPELL | PROC_FLAG_TAKE_HARMFUL_SPELL
-                                                | PROC_FLAG_TAKE_PERIODIC | PROC_FLAG_TAKE_ANY_DAMAGE,
+    TAKEN_HIT_PROC_FLAG_MASK = PROC_FLAG_TAKE_MELEE_SWING | PROC_FLAG_TAKE_RANGED_ATTACK | PROC_FLAG_TAKE_MELEE_ABILITY | PROC_FLAG_TAKE_RANGED_ABILITY | PROC_FLAG_TAKE_HELPFUL_ABILITY |
+                               PROC_FLAG_TAKE_HARMFUL_ABILITY | PROC_FLAG_TAKE_HELPFUL_SPELL | PROC_FLAG_TAKE_HARMFUL_SPELL | PROC_FLAG_TAKE_PERIODIC | PROC_FLAG_TAKE_ANY_DAMAGE,
 
-    REQ_SPELL_PHASE_PROC_FLAG_MASK             = SPELL_PROC_FLAG_MASK & DONE_HIT_PROC_FLAG_MASK
+    REQ_SPELL_PHASE_PROC_FLAG_MASK = SPELL_PROC_FLAG_MASK & DONE_HIT_PROC_FLAG_MASK
 };
 
-#define MELEE_BASED_TRIGGER_MASK (PROC_FLAG_DEAL_MELEE_SWING    | \
-                                  PROC_FLAG_TAKE_MELEE_SWING    | \
-                                  PROC_FLAG_DEAL_MELEE_ABILITY  | \
-                                  PROC_FLAG_TAKE_MELEE_ABILITY  | \
-                                  PROC_FLAG_DEAL_RANGED_ATTACK  | \
-                                  PROC_FLAG_TAKE_RANGED_ATTACK  | \
-                                  PROC_FLAG_DEAL_RANGED_ABILITY | \
-                                  PROC_FLAG_TAKE_RANGED_ABILITY)
+#define MELEE_BASED_TRIGGER_MASK                                                                                                                                                                       \
+    (PROC_FLAG_DEAL_MELEE_SWING | PROC_FLAG_TAKE_MELEE_SWING | PROC_FLAG_DEAL_MELEE_ABILITY | PROC_FLAG_TAKE_MELEE_ABILITY | PROC_FLAG_DEAL_RANGED_ATTACK | PROC_FLAG_TAKE_RANGED_ATTACK |             \
+        PROC_FLAG_DEAL_RANGED_ABILITY | PROC_FLAG_TAKE_RANGED_ABILITY)
 
 enum ProcFlagsSpellType
 {
-    PROC_SPELL_TYPE_NONE              = 0x0000000,
-    PROC_SPELL_TYPE_DAMAGE            = 0x0000001, // damage type of spell
-    PROC_SPELL_TYPE_HEAL              = 0x0000002, // heal type of spell
-    PROC_SPELL_TYPE_NO_DMG_HEAL       = 0x0000004, // other spells
-    PROC_SPELL_TYPE_MASK_ALL          = PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_HEAL | PROC_SPELL_TYPE_NO_DMG_HEAL
+    PROC_SPELL_TYPE_NONE = 0x0000000,
+    PROC_SPELL_TYPE_DAMAGE = 0x0000001,      // damage type of spell
+    PROC_SPELL_TYPE_HEAL = 0x0000002,        // heal type of spell
+    PROC_SPELL_TYPE_NO_DMG_HEAL = 0x0000004, // other spells
+    PROC_SPELL_TYPE_MASK_ALL = PROC_SPELL_TYPE_DAMAGE | PROC_SPELL_TYPE_HEAL | PROC_SPELL_TYPE_NO_DMG_HEAL
 };
 
 enum ProcFlagsSpellPhase
 {
-    PROC_SPELL_PHASE_NONE             = 0x0000000,
-    PROC_SPELL_PHASE_CAST             = 0x0000001,
-    PROC_SPELL_PHASE_HIT              = 0x0000002,
-    PROC_SPELL_PHASE_FINISH           = 0x0000004,
-    PROC_SPELL_PHASE_MASK_ALL         = PROC_SPELL_PHASE_CAST | PROC_SPELL_PHASE_HIT | PROC_SPELL_PHASE_FINISH
+    PROC_SPELL_PHASE_NONE = 0x0000000,
+    PROC_SPELL_PHASE_CAST = 0x0000001,
+    PROC_SPELL_PHASE_HIT = 0x0000002,
+    PROC_SPELL_PHASE_FINISH = 0x0000004,
+    PROC_SPELL_PHASE_MASK_ALL = PROC_SPELL_PHASE_CAST | PROC_SPELL_PHASE_HIT | PROC_SPELL_PHASE_FINISH
 };
 
 enum ProcFlagsHit
 {
-    PROC_HIT_NONE                = 0x0000000, // no value - PROC_HIT_NORMAL | PROC_HIT_CRITICAL for TAKEN proc type, PROC_HIT_NORMAL | PROC_HIT_CRITICAL | PROC_HIT_ABSORB for DONE
-    PROC_HIT_NORMAL              = 0x0000001, // non-critical hits
-    PROC_HIT_CRITICAL            = 0x0000002,
-    PROC_HIT_MISS                = 0x0000004,
-    PROC_HIT_FULL_RESIST         = 0x0000008,
-    PROC_HIT_DODGE               = 0x0000010,
-    PROC_HIT_PARRY               = 0x0000020,
-    PROC_HIT_BLOCK               = 0x0000040, // partial or full block
-    PROC_HIT_EVADE               = 0x0000080,
-    PROC_HIT_IMMUNE              = 0x0000100,
-    PROC_HIT_DEFLECT             = 0x0000200,
-    PROC_HIT_ABSORB              = 0x0000400, // partial or full absorb
-    PROC_HIT_REFLECT             = 0x0000800,
-    PROC_HIT_INTERRUPT           = 0x0001000,
-    PROC_HIT_FULL_BLOCK          = 0x0002000,
-    PROC_HIT_MASK_ALL            = 0x0003FFF
+    PROC_HIT_NONE = 0x0000000,   // no value - PROC_HIT_NORMAL | PROC_HIT_CRITICAL for TAKEN proc type, PROC_HIT_NORMAL | PROC_HIT_CRITICAL | PROC_HIT_ABSORB for DONE
+    PROC_HIT_NORMAL = 0x0000001, // non-critical hits
+    PROC_HIT_CRITICAL = 0x0000002,
+    PROC_HIT_MISS = 0x0000004,
+    PROC_HIT_FULL_RESIST = 0x0000008,
+    PROC_HIT_DODGE = 0x0000010,
+    PROC_HIT_PARRY = 0x0000020,
+    PROC_HIT_BLOCK = 0x0000040, // partial or full block
+    PROC_HIT_EVADE = 0x0000080,
+    PROC_HIT_IMMUNE = 0x0000100,
+    PROC_HIT_DEFLECT = 0x0000200,
+    PROC_HIT_ABSORB = 0x0000400, // partial or full absorb
+    PROC_HIT_REFLECT = 0x0000800,
+    PROC_HIT_INTERRUPT = 0x0001000,
+    PROC_HIT_FULL_BLOCK = 0x0002000,
+    PROC_HIT_MASK_ALL = 0x0003FFF
 };
 
 enum ProcAttributes
 {
-    PROC_ATTR_REQ_EXP_OR_HONOR          = 0x0000001, // requires proc target to give exp or honor for aura proc
-    PROC_ATTR_TRIGGERED_CAN_PROC        = 0x0000002, // aura can proc even with triggered spells
-    PROC_ATTR_REQ_MANA_COST             = 0x0000004, // requires triggering spell to have a mana cost for aura proc
-    PROC_ATTR_REQ_SPELLMOD              = 0x0000008, // requires triggering spell to be affected by proccing aura to drop charges
-    PROC_ATTR_USE_STACKS_FOR_CHARGES    = 0x0000010, // consuming proc drops a stack from proccing aura instead of charge
-    PROC_ATTR_REDUCE_PROC_60            = 0x0000080, // aura should have a reduced chance to proc if level of proc Actor > 60
+    PROC_ATTR_REQ_EXP_OR_HONOR = 0x0000001,       // requires proc target to give exp or honor for aura proc
+    PROC_ATTR_TRIGGERED_CAN_PROC = 0x0000002,     // aura can proc even with triggered spells
+    PROC_ATTR_REQ_MANA_COST = 0x0000004,          // requires triggering spell to have a mana cost for aura proc
+    PROC_ATTR_REQ_SPELLMOD = 0x0000008,           // requires triggering spell to be affected by proccing aura to drop charges
+    PROC_ATTR_USE_STACKS_FOR_CHARGES = 0x0000010, // consuming proc drops a stack from proccing aura instead of charge
+    PROC_ATTR_REDUCE_PROC_60 = 0x0000080,         // aura should have a reduced chance to proc if level of proc Actor > 60
 
-    PROC_ATTR_CANT_PROC_FROM_ITEM_CAST  = 0x0000100, // do not allow aura proc if proc is caused by a spell casted by item
+    PROC_ATTR_CANT_PROC_FROM_ITEM_CAST = 0x0000100, // do not allow aura proc if proc is caused by a spell casted by item
 };
 
 struct SpellProcEntry
 {
-    uint32 SchoolMask;      // if nonzero - bitmask for matching proc condition based on spell's school
-    uint32 SpellFamilyName; // if nonzero - for matching proc condition based on candidate spell's SpellFamilyName
-    flag96 SpellFamilyMask; // if nonzero - bitmask for matching proc condition based on candidate spell's SpellFamilyFlags
-    uint32 ProcFlags;       // if nonzero - owerwrite procFlags field for given Spell.dbc entry, bitmask for matching proc condition, see enum ProcFlags
-    uint32 SpellTypeMask;   // if nonzero - bitmask for matching proc condition based on candidate spell's damage/heal effects, see enum ProcFlagsSpellType
-    uint32 SpellPhaseMask;  // if nonzero - bitmask for matching phase of a spellcast on which proc occurs, see enum ProcFlagsSpellPhase
-    uint32 HitMask;         // if nonzero - bitmask for matching proc condition based on hit result, see enum ProcFlagsHit
-    uint32 AttributesMask;  // bitmask, see ProcAttributes
-    uint32 DisableEffectsMask;// bitmask
-    float ProcsPerMinute;   // if nonzero - chance to proc is equal to value * aura caster's weapon speed / 60
-    float Chance;           // if nonzero - owerwrite procChance field for given Spell.dbc entry, defines chance of proc to occur, not used if ProcsPerMinute set
-    Milliseconds Cooldown;  // if nonzero - cooldown in secs for aura proc, applied to aura
-    uint32 Charges;         // if nonzero - owerwrite procCharges field for given Spell.dbc entry, defines how many times proc can occur before aura remove, 0 - infinite
+    uint32 SchoolMask;         // if nonzero - bitmask for matching proc condition based on spell's school
+    uint32 SpellFamilyName;    // if nonzero - for matching proc condition based on candidate spell's SpellFamilyName
+    flag96 SpellFamilyMask;    // if nonzero - bitmask for matching proc condition based on candidate spell's SpellFamilyFlags
+    uint32 ProcFlags;          // if nonzero - owerwrite procFlags field for given Spell.dbc entry, bitmask for matching proc condition, see enum ProcFlags
+    uint32 SpellTypeMask;      // if nonzero - bitmask for matching proc condition based on candidate spell's damage/heal effects, see enum ProcFlagsSpellType
+    uint32 SpellPhaseMask;     // if nonzero - bitmask for matching phase of a spellcast on which proc occurs, see enum ProcFlagsSpellPhase
+    uint32 HitMask;            // if nonzero - bitmask for matching proc condition based on hit result, see enum ProcFlagsHit
+    uint32 AttributesMask;     // bitmask, see ProcAttributes
+    uint32 DisableEffectsMask; // bitmask
+    float ProcsPerMinute;      // if nonzero - chance to proc is equal to value * aura caster's weapon speed / 60
+    float Chance;              // if nonzero - owerwrite procChance field for given Spell.dbc entry, defines chance of proc to occur, not used if ProcsPerMinute set
+    Milliseconds Cooldown;     // if nonzero - cooldown in secs for aura proc, applied to aura
+    uint32 Charges;            // if nonzero - owerwrite procCharges field for given Spell.dbc entry, defines how many times proc can occur before aura remove, 0 - infinite
 };
 
 typedef std::unordered_map<uint32, SpellProcEntry> SpellProcMap;
@@ -273,52 +252,48 @@ typedef std::unordered_map<uint32, SpellProcEntry> SpellProcMap;
 enum EnchantProcAttributes
 {
     ENCHANT_PROC_ATTR_WHITE_HIT = 0x0000001, // enchant shall only proc off white hits (not abilities)
-    ENCHANT_PROC_ATTR_LIMIT_60  = 0x0000002  // enchant effects shall be reduced past lvl 60
+    ENCHANT_PROC_ATTR_LIMIT_60 = 0x0000002   // enchant effects shall be reduced past lvl 60
 };
 
 struct SpellEnchantProcEntry
 {
-    SpellEnchantProcEntry() : Chance(0.f), ProcsPerMinute(0.f), HitMask(0), AttributesMask(0.f) { }
+    SpellEnchantProcEntry() : Chance(0.f), ProcsPerMinute(0.f), HitMask(0), AttributesMask(0.f) {}
 
-    float   Chance;         // if nonzero - overwrite SpellItemEnchantment value
-    float   ProcsPerMinute; // if nonzero - chance to proc is equal to value * aura caster's weapon speed / 60
-    uint32  HitMask;        // if nonzero - bitmask for matching proc condition based on hit result, see enum ProcFlagsHit
-    uint32  AttributesMask; // bitmask, see EnchantProcAttributes
+    float Chance;          // if nonzero - overwrite SpellItemEnchantment value
+    float ProcsPerMinute;  // if nonzero - chance to proc is equal to value * aura caster's weapon speed / 60
+    uint32 HitMask;        // if nonzero - bitmask for matching proc condition based on hit result, see enum ProcFlagsHit
+    uint32 AttributesMask; // bitmask, see EnchantProcAttributes
 };
 
 typedef std::unordered_map<uint32, SpellEnchantProcEntry> SpellEnchantProcEventMap;
 
 struct SpellBonusEntry
 {
-    float  direct_damage;
-    float  dot_damage;
-    float  ap_bonus;
-    float  ap_dot_bonus;
+    float direct_damage;
+    float dot_damage;
+    float ap_bonus;
+    float ap_dot_bonus;
 };
 
-typedef std::unordered_map<uint32, SpellBonusEntry>     SpellBonusMap;
+typedef std::unordered_map<uint32, SpellBonusEntry> SpellBonusMap;
 
 enum SpellGroup
 {
-    SPELL_GROUP_NONE             = 0,
-    SPELL_GROUP_ELIXIR_BATTLE    = 1,
-    SPELL_GROUP_ELIXIR_GUARDIAN  = 2,
-    SPELL_GROUP_ELIXIR_UNSTABLE  = 3,
+    SPELL_GROUP_NONE = 0,
+    SPELL_GROUP_ELIXIR_BATTLE = 1,
+    SPELL_GROUP_ELIXIR_GUARDIAN = 2,
+    SPELL_GROUP_ELIXIR_UNSTABLE = 3,
     SPELL_GROUP_ELIXIR_SHATTRATH = 4,
-    SPELL_GROUP_CORE_RANGE_MAX   = 5
+    SPELL_GROUP_CORE_RANGE_MAX = 5
 };
 
 namespace std
 {
-    template<>
-    struct hash<SpellGroup>
+    template <> struct hash<SpellGroup>
     {
-        size_t operator()(SpellGroup const& group) const
-        {
-            return hash<uint32>()(uint32(group));
-        }
+        size_t operator()(SpellGroup const& group) const { return hash<uint32>()(uint32(group)); }
     };
-}
+} // namespace std
 
 #define SPELL_GROUP_DB_RANGE_MIN 1000
 
@@ -346,7 +321,7 @@ typedef std::unordered_map<SpellGroup, std::unordered_set<uint32 /*auraName*/>> 
 
 struct SpellThreatEntry
 {
-    SpellThreatEntry() : flatMod(0), pctMod(1.f), apPctMod(0.f) { }
+    SpellThreatEntry() : flatMod(0), pctMod(1.f), apPctMod(0.f) {}
 
     int32 flatMod;  // flat threat-value for this Spell  - default: 0
     float pctMod;   // threat-multiplier for this Spell  - default: 1.0f
@@ -358,13 +333,13 @@ typedef std::unordered_map<uint32, SpellThreatEntry> SpellThreatMap;
 // coordinates for spells (accessed using SpellMgr functions)
 struct SpellTargetPosition
 {
-    SpellTargetPosition() : target_mapId(0), target_X(0.f), target_Y(0.f), target_Z(0.f), target_Orientation(0.f) { }
+    SpellTargetPosition() : target_mapId(0), target_X(0.f), target_Y(0.f), target_Z(0.f), target_Orientation(0.f) {}
 
     uint32 target_mapId;
-    float  target_X;
-    float  target_Y;
-    float  target_Z;
-    float  target_Orientation;
+    float target_X;
+    float target_Y;
+    float target_Z;
+    float target_Orientation;
 };
 
 typedef std::map<std::pair<uint32 /*spell_id*/, SpellEffIndex /*effIndex*/>, SpellTargetPosition> SpellTargetPositionMap;
@@ -372,132 +347,120 @@ typedef std::map<std::pair<uint32 /*spell_id*/, SpellEffIndex /*effIndex*/>, Spe
 // Enum with EffectRadiusIndex and their actual radius
 enum EffectRadiusIndex
 {
-    EFFECT_RADIUS_2_YARDS       = 7,
-    EFFECT_RADIUS_5_YARDS       = 8,
-    EFFECT_RADIUS_20_YARDS      = 9,
-    EFFECT_RADIUS_30_YARDS      = 10,
-    EFFECT_RADIUS_45_YARDS      = 11,
-    EFFECT_RADIUS_100_YARDS     = 12,
-    EFFECT_RADIUS_10_YARDS      = 13,
-    EFFECT_RADIUS_8_YARDS       = 14,
-    EFFECT_RADIUS_3_YARDS       = 15,
-    EFFECT_RADIUS_1_YARD        = 16,
-    EFFECT_RADIUS_13_YARDS      = 17,
-    EFFECT_RADIUS_15_YARDS      = 18,
-    EFFECT_RADIUS_18_YARDS      = 19,
-    EFFECT_RADIUS_25_YARDS      = 20,
-    EFFECT_RADIUS_35_YARDS      = 21,
-    EFFECT_RADIUS_200_YARDS     = 22,
-    EFFECT_RADIUS_40_YARDS      = 23,
-    EFFECT_RADIUS_65_YARDS      = 24,
-    EFFECT_RADIUS_70_YARDS      = 25,
-    EFFECT_RADIUS_4_YARDS       = 26,
-    EFFECT_RADIUS_50_YARDS      = 27,
-    EFFECT_RADIUS_50000_YARDS   = 28,
-    EFFECT_RADIUS_6_YARDS       = 29,
-    EFFECT_RADIUS_500_YARDS     = 30,
-    EFFECT_RADIUS_80_YARDS      = 31,
-    EFFECT_RADIUS_12_YARDS      = 32,
-    EFFECT_RADIUS_99_YARDS      = 33,
-    EFFECT_RADIUS_55_YARDS      = 35,
-    EFFECT_RADIUS_0_YARDS       = 36,
-    EFFECT_RADIUS_7_YARDS       = 37,
-    EFFECT_RADIUS_21_YARDS      = 38,
-    EFFECT_RADIUS_34_YARDS      = 39,
-    EFFECT_RADIUS_9_YARDS       = 40,
-    EFFECT_RADIUS_150_YARDS     = 41,
-    EFFECT_RADIUS_11_YARDS      = 42,
-    EFFECT_RADIUS_16_YARDS      = 43,
-    EFFECT_RADIUS_0_5_YARDS     = 44,   // 0.5 yards
-    EFFECT_RADIUS_10_YARDS_2    = 45,
-    EFFECT_RADIUS_5_YARDS_2     = 46,
-    EFFECT_RADIUS_15_YARDS_2    = 47,
-    EFFECT_RADIUS_60_YARDS      = 48,
-    EFFECT_RADIUS_90_YARDS      = 49,
-    EFFECT_RADIUS_15_YARDS_3    = 50,
-    EFFECT_RADIUS_60_YARDS_2    = 51,
-    EFFECT_RADIUS_5_YARDS_3     = 52,
-    EFFECT_RADIUS_60_YARDS_3    = 53,
+    EFFECT_RADIUS_2_YARDS = 7,
+    EFFECT_RADIUS_5_YARDS = 8,
+    EFFECT_RADIUS_20_YARDS = 9,
+    EFFECT_RADIUS_30_YARDS = 10,
+    EFFECT_RADIUS_45_YARDS = 11,
+    EFFECT_RADIUS_100_YARDS = 12,
+    EFFECT_RADIUS_10_YARDS = 13,
+    EFFECT_RADIUS_8_YARDS = 14,
+    EFFECT_RADIUS_3_YARDS = 15,
+    EFFECT_RADIUS_1_YARD = 16,
+    EFFECT_RADIUS_13_YARDS = 17,
+    EFFECT_RADIUS_15_YARDS = 18,
+    EFFECT_RADIUS_18_YARDS = 19,
+    EFFECT_RADIUS_25_YARDS = 20,
+    EFFECT_RADIUS_35_YARDS = 21,
+    EFFECT_RADIUS_200_YARDS = 22,
+    EFFECT_RADIUS_40_YARDS = 23,
+    EFFECT_RADIUS_65_YARDS = 24,
+    EFFECT_RADIUS_70_YARDS = 25,
+    EFFECT_RADIUS_4_YARDS = 26,
+    EFFECT_RADIUS_50_YARDS = 27,
+    EFFECT_RADIUS_50000_YARDS = 28,
+    EFFECT_RADIUS_6_YARDS = 29,
+    EFFECT_RADIUS_500_YARDS = 30,
+    EFFECT_RADIUS_80_YARDS = 31,
+    EFFECT_RADIUS_12_YARDS = 32,
+    EFFECT_RADIUS_99_YARDS = 33,
+    EFFECT_RADIUS_55_YARDS = 35,
+    EFFECT_RADIUS_0_YARDS = 36,
+    EFFECT_RADIUS_7_YARDS = 37,
+    EFFECT_RADIUS_21_YARDS = 38,
+    EFFECT_RADIUS_34_YARDS = 39,
+    EFFECT_RADIUS_9_YARDS = 40,
+    EFFECT_RADIUS_150_YARDS = 41,
+    EFFECT_RADIUS_11_YARDS = 42,
+    EFFECT_RADIUS_16_YARDS = 43,
+    EFFECT_RADIUS_0_5_YARDS = 44, // 0.5 yards
+    EFFECT_RADIUS_10_YARDS_2 = 45,
+    EFFECT_RADIUS_5_YARDS_2 = 46,
+    EFFECT_RADIUS_15_YARDS_2 = 47,
+    EFFECT_RADIUS_60_YARDS = 48,
+    EFFECT_RADIUS_90_YARDS = 49,
+    EFFECT_RADIUS_15_YARDS_3 = 50,
+    EFFECT_RADIUS_60_YARDS_2 = 51,
+    EFFECT_RADIUS_5_YARDS_3 = 52,
+    EFFECT_RADIUS_60_YARDS_3 = 53,
     EFFECT_RADIUS_50000_YARDS_2 = 54,
-    EFFECT_RADIUS_130_YARDS     = 55,
-    EFFECT_RADIUS_38_YARDS      = 56,
-    EFFECT_RADIUS_45_YARDS_2    = 57,
-    EFFECT_RADIUS_32_YARDS      = 59,
-    EFFECT_RADIUS_44_YARDS      = 60,
-    EFFECT_RADIUS_14_YARDS      = 61,
-    EFFECT_RADIUS_47_YARDS      = 62,
-    EFFECT_RADIUS_23_YARDS      = 63,
-    EFFECT_RADIUS_3_5_YARDS     = 64,   // 3.5 yards
-    EFFECT_RADIUS_80_YARDS_2    = 65,
-    EFFECT_RADIUS_1_5_YARDS     = 73    // 1.5 yards
+    EFFECT_RADIUS_130_YARDS = 55,
+    EFFECT_RADIUS_38_YARDS = 56,
+    EFFECT_RADIUS_45_YARDS_2 = 57,
+    EFFECT_RADIUS_32_YARDS = 59,
+    EFFECT_RADIUS_44_YARDS = 60,
+    EFFECT_RADIUS_14_YARDS = 61,
+    EFFECT_RADIUS_47_YARDS = 62,
+    EFFECT_RADIUS_23_YARDS = 63,
+    EFFECT_RADIUS_3_5_YARDS = 64, // 3.5 yards
+    EFFECT_RADIUS_80_YARDS_2 = 65,
+    EFFECT_RADIUS_1_5_YARDS = 73 // 1.5 yards
 };
 
 // Spell pet auras
 class FC_GAME_API PetAura
 {
-    private:
-        typedef std::unordered_map<uint32, uint32> PetAuraMap;
+  private:
+    typedef std::unordered_map<uint32, uint32> PetAuraMap;
 
-    public:
-        PetAura() : removeOnChangePet(false), damage(0) { }
+  public:
+    PetAura() : removeOnChangePet(false), damage(0) {}
 
-        PetAura(uint32 petEntry, uint32 aura, bool _removeOnChangePet, int _damage) :
-        removeOnChangePet(_removeOnChangePet), damage(_damage)
-        {
-            auras[petEntry] = aura;
-        }
+    PetAura(uint32 petEntry, uint32 aura, bool _removeOnChangePet, int _damage) : removeOnChangePet(_removeOnChangePet), damage(_damage) { auras[petEntry] = aura; }
 
-        uint32 GetAura(uint32 petEntry) const
-        {
-            PetAuraMap::const_iterator itr = auras.find(petEntry);
-            if (itr != auras.end())
-                return itr->second;
-            PetAuraMap::const_iterator itr2 = auras.find(0);
-            if (itr2 != auras.end())
-                return itr2->second;
-            return 0;
-        }
+    uint32 GetAura(uint32 petEntry) const
+    {
+        PetAuraMap::const_iterator itr = auras.find(petEntry);
+        if (itr != auras.end())
+            return itr->second;
+        PetAuraMap::const_iterator itr2 = auras.find(0);
+        if (itr2 != auras.end())
+            return itr2->second;
+        return 0;
+    }
 
-        void AddAura(uint32 petEntry, uint32 aura)
-        {
-            auras[petEntry] = aura;
-        }
+    void AddAura(uint32 petEntry, uint32 aura) { auras[petEntry] = aura; }
 
-        bool IsRemovedOnChangePet() const
-        {
-            return removeOnChangePet;
-        }
+    bool IsRemovedOnChangePet() const { return removeOnChangePet; }
 
-        int32 GetDamage() const
-        {
-            return damage;
-        }
+    int32 GetDamage() const { return damage; }
 
-    private:
-        PetAuraMap auras;
-        bool removeOnChangePet;
-        int32 damage;
+  private:
+    PetAuraMap auras;
+    bool removeOnChangePet;
+    int32 damage;
 };
 typedef std::map<uint32, PetAura> SpellPetAuraMap;
 
 enum SpellAreaFlag
 {
-    SPELL_AREA_FLAG_AUTOCAST   = 0x1, // if has autocast, spell is applied on enter
-    SPELL_AREA_FLAG_AUTOREMOVE = 0x2  // if has autoremove, spell is remove automatically inside zone/area (always removed on leaving area or zone)
+    SPELL_AREA_FLAG_AUTOCAST = 0x1,  // if has autocast, spell is applied on enter
+    SPELL_AREA_FLAG_AUTOREMOVE = 0x2 // if has autoremove, spell is remove automatically inside zone/area (always removed on leaving area or zone)
 };
 
 struct FC_GAME_API SpellArea
 {
     uint32 spellId;
-    uint32 areaId;                                          // zone/subzone/or 0 is not limited to zone
-    uint32 questStart;                                      // quest start (quest must be active or rewarded for spell apply)
-    uint32 questEnd;                                        // quest end (quest must not be rewarded for spell apply)
-    int32  auraSpell;                                       // spell aura must be applied for spell apply)if possitive) and it must not be applied in other case
-    uint32 raceMask;                                        // can be applied only to races
-    Gender gender;                                          // can be applied only to gender
-    uint32 questStartStatus;                                // QuestStatus that quest_start must have in order to keep the spell
-    uint32 questEndStatus;                                  // QuestStatus that the quest_end must have in order to keep the spell (if the quest_end's status is different than this, the spell will be dropped)
-    uint8 flags;                                            // if SPELL_AREA_FLAG_AUTOCAST then auto applied at area enter, in other case just allowed to cast || if SPELL_AREA_FLAG_AUTOREMOVE then auto removed inside area (will allways be removed on leaved even without flag)
+    uint32 areaId;           // zone/subzone/or 0 is not limited to zone
+    uint32 questStart;       // quest start (quest must be active or rewarded for spell apply)
+    uint32 questEnd;         // quest end (quest must not be rewarded for spell apply)
+    int32 auraSpell;         // spell aura must be applied for spell apply)if possitive) and it must not be applied in other case
+    uint32 raceMask;         // can be applied only to races
+    Gender gender;           // can be applied only to gender
+    uint32 questStartStatus; // QuestStatus that quest_start must have in order to keep the spell
+    uint32 questEndStatus;   // QuestStatus that the quest_end must have in order to keep the spell (if the quest_end's status is different than this, the spell will be dropped)
+    uint8 flags; // if SPELL_AREA_FLAG_AUTOCAST then auto applied at area enter, in other case just allowed to cast || if SPELL_AREA_FLAG_AUTOREMOVE then auto removed inside area (will allways be
+                 // removed on leaved even without flag)
     ConditionContainer Conditions;
 
     // helpers
@@ -510,19 +473,19 @@ typedef std::multimap<uint32, SpellArea*> SpellAreaForAuraMap;
 typedef std::multimap<uint32, SpellArea*> SpellAreaForAreaMap;
 typedef std::pair<SpellAreaMap::const_iterator, SpellAreaMap::const_iterator> SpellAreaMapBounds;
 typedef std::pair<SpellAreaForQuestMap::const_iterator, SpellAreaForQuestMap::const_iterator> SpellAreaForQuestMapBounds;
-typedef std::pair<SpellAreaForAuraMap::const_iterator, SpellAreaForAuraMap::const_iterator>  SpellAreaForAuraMapBounds;
-typedef std::pair<SpellAreaForAreaMap::const_iterator, SpellAreaForAreaMap::const_iterator>  SpellAreaForAreaMapBounds;
+typedef std::pair<SpellAreaForAuraMap::const_iterator, SpellAreaForAuraMap::const_iterator> SpellAreaForAuraMapBounds;
+typedef std::pair<SpellAreaForAreaMap::const_iterator, SpellAreaForAreaMap::const_iterator> SpellAreaForAreaMapBounds;
 
 // Spell rank chain  (accessed using SpellMgr functions)
 struct SpellChainNode
 {
-    SpellChainNode() : prev(nullptr), next(nullptr), first(nullptr), last(nullptr), rank(0) { }
+    SpellChainNode() : prev(nullptr), next(nullptr), first(nullptr), last(nullptr), rank(0) {}
 
     SpellInfo const* prev;
     SpellInfo const* next;
     SpellInfo const* first;
     SpellInfo const* last;
-    uint8  rank;
+    uint8 rank;
 };
 
 typedef std::unordered_map<uint32, SpellChainNode> SpellChainMap;
@@ -538,22 +501,22 @@ typedef std::pair<SpellsRequiringSpellMap::const_iterator, SpellsRequiringSpellM
 // Spell learning properties (accessed using SpellMgr functions)
 struct SpellLearnSkillNode
 {
-    SpellLearnSkillNode() : skill(0), step(0), value(0), maxvalue(0) { }
+    SpellLearnSkillNode() : skill(0), step(0), value(0), maxvalue(0) {}
 
     uint16 skill;
     uint16 step;
-    uint16 value;                                           // 0  - max skill value for player level
-    uint16 maxvalue;                                        // 0  - max skill value for player level
+    uint16 value;    // 0  - max skill value for player level
+    uint16 maxvalue; // 0  - max skill value for player level
 };
 
 typedef std::unordered_map<uint32, SpellLearnSkillNode> SpellLearnSkillMap;
 
 struct SpellLearnSpellNode
 {
-    SpellLearnSpellNode() : spell(0), active(false), autoLearned(false) { }
+    SpellLearnSpellNode() : spell(0), active(false), autoLearned(false) {}
 
     uint32 spell;
-    bool active;                                            // show in spellbook or not
+    bool active; // show in spellbook or not
     bool autoLearned;
 };
 
@@ -570,7 +533,7 @@ typedef std::map<uint32, uint32> SpellDifficultySearcherMap;
 
 struct PetDefaultSpellsEntry
 {
-    PetDefaultSpellsEntry() : spellid({ }) { }
+    PetDefaultSpellsEntry() : spellid({}) {}
 
     std::array<uint32, MAX_CREATURE_SPELL_DATA_SLOT> spellid;
 };
@@ -578,189 +541,180 @@ struct PetDefaultSpellsEntry
 // < 0 for petspelldata id, > 0 for creature_id
 typedef std::map<int32, PetDefaultSpellsEntry> PetDefaultSpellsMap;
 
-typedef std::vector<uint32> SpellCustomAttribute;
-
 typedef std::vector<SpellInfo*> SpellInfoMap;
 
-typedef std::map<int32, std::vector<int32> > SpellLinkedMap;
+typedef std::unordered_map<int32, std::vector<int32>> SpellLinkedMap;
 
 bool IsPrimaryProfessionSkill(uint32 skill);
 
 bool IsWeaponSkill(uint32 skill);
 
-inline bool IsProfessionSkill(uint32 skill)
-{
-    return  IsPrimaryProfessionSkill(skill) || skill == SKILL_FISHING || skill == SKILL_COOKING || skill == SKILL_FIRST_AID || skill == SKILL_ARCHAEOLOGY;
-}
+inline bool IsProfessionSkill(uint32 skill) { return IsPrimaryProfessionSkill(skill) || skill == SKILL_FISHING || skill == SKILL_COOKING || skill == SKILL_FIRST_AID || skill == SKILL_ARCHAEOLOGY; }
 
-inline bool IsProfessionOrRidingSkill(uint32 skill)
-{
-    return  IsProfessionSkill(skill) || skill == SKILL_RIDING;
-}
+inline bool IsProfessionOrRidingSkill(uint32 skill) { return IsProfessionSkill(skill) || skill == SKILL_RIDING; }
 
 bool IsPartOfSkillLine(uint32 skillId, uint32 spellId);
 
 class FC_GAME_API SpellMgr
 {
     // Constructors
-    private:
-        SpellMgr();
-        ~SpellMgr();
+  private:
+    SpellMgr();
+    ~SpellMgr();
 
     // Accessors (const or static functions)
-    public:
-        static SpellMgr* instance();
+  public:
+    static SpellMgr* instance();
 
-        // Spell correctness for client using
-        static bool IsSpellValid(SpellInfo const* spellInfo, Player* player = nullptr, bool msg = true);
+    // Spell correctness for client using
+    static bool IsSpellValid(SpellInfo const* spellInfo, Player* player = nullptr, bool msg = true);
 
-        // Spell difficulty
-        uint32 GetSpellDifficultyId(uint32 spellId) const;
-        void SetSpellDifficultyId(uint32 spellId, uint32 id);
-        uint32 GetSpellIdForDifficulty(uint32 spellId, Unit const* caster) const;
-        SpellInfo const* GetSpellForDifficultyFromSpell(SpellInfo const* spell, Unit const* caster) const;
+    // Spell difficulty
+    uint32 GetSpellDifficultyId(uint32 spellId) const;
+    void SetSpellDifficultyId(uint32 spellId, uint32 id);
+    uint32 GetSpellIdForDifficulty(uint32 spellId, Unit const* caster) const;
+    SpellInfo const* GetSpellForDifficultyFromSpell(SpellInfo const* spell, Unit const* caster) const;
 
-        // Spell Ranks table
-        SpellChainNode const* GetSpellChainNode(uint32 spell_id) const;
-        uint32 GetFirstSpellInChain(uint32 spell_id) const;
-        uint32 GetLastSpellInChain(uint32 spell_id) const;
-        uint32 GetNextSpellInChain(uint32 spell_id) const;
-        uint32 GetPrevSpellInChain(uint32 spell_id) const;
-        uint8 GetSpellRank(uint32 spell_id) const;
-        // not strict check returns provided spell if rank not avalible
-        uint32 GetSpellWithRank(uint32 spell_id, uint32 rank, bool strict = false) const;
+    // Spell Ranks table
+    SpellChainNode const* GetSpellChainNode(uint32 spell_id) const;
+    uint32 GetFirstSpellInChain(uint32 spell_id) const;
+    uint32 GetLastSpellInChain(uint32 spell_id) const;
+    uint32 GetNextSpellInChain(uint32 spell_id) const;
+    uint32 GetPrevSpellInChain(uint32 spell_id) const;
+    uint8 GetSpellRank(uint32 spell_id) const;
+    // not strict check returns provided spell if rank not avalible
+    uint32 GetSpellWithRank(uint32 spell_id, uint32 rank, bool strict = false) const;
 
-        // Spell Required table
-        Firelands::IteratorPair<SpellRequiredMap::const_iterator> GetSpellsRequiredForSpellBounds(uint32 spell_id) const;
-        SpellsRequiringSpellMapBounds GetSpellsRequiringSpellBounds(uint32 spell_id) const;
-        bool IsSpellRequiringSpell(uint32 spellid, uint32 req_spellid) const;
+    // Spell Required table
+    Firelands::IteratorPair<SpellRequiredMap::const_iterator> GetSpellsRequiredForSpellBounds(uint32 spell_id) const;
+    SpellsRequiringSpellMapBounds GetSpellsRequiringSpellBounds(uint32 spell_id) const;
+    bool IsSpellRequiringSpell(uint32 spellid, uint32 req_spellid) const;
 
-        // Spell learning
-        SpellLearnSkillNode const* GetSpellLearnSkill(uint32 spell_id) const;
-        SpellLearnSpellMapBounds GetSpellLearnSpellMapBounds(uint32 spell_id) const;
-        bool IsSpellLearnSpell(uint32 spell_id) const;
-        bool IsSpellLearnToSpell(uint32 spell_id1, uint32 spell_id2) const;
+    // Spell learning
+    SpellLearnSkillNode const* GetSpellLearnSkill(uint32 spell_id) const;
+    SpellLearnSpellMapBounds GetSpellLearnSpellMapBounds(uint32 spell_id) const;
+    bool IsSpellLearnSpell(uint32 spell_id) const;
+    bool IsSpellLearnToSpell(uint32 spell_id1, uint32 spell_id2) const;
 
-        // Spell target coordinates
-        SpellTargetPosition const* GetSpellTargetPosition(uint32 spell_id, SpellEffIndex effIndex) const;
+    // Spell target coordinates
+    SpellTargetPosition const* GetSpellTargetPosition(uint32 spell_id, SpellEffIndex effIndex) const;
 
-        // Spell Groups table
-        SpellSpellGroupMapBounds GetSpellSpellGroupMapBounds(uint32 spell_id) const;
-        bool IsSpellMemberOfSpellGroup(uint32 spellid, SpellGroup groupid) const;
+    // Spell Groups table
+    SpellSpellGroupMapBounds GetSpellSpellGroupMapBounds(uint32 spell_id) const;
+    bool IsSpellMemberOfSpellGroup(uint32 spellid, SpellGroup groupid) const;
 
-        SpellGroupSpellMapBounds GetSpellGroupSpellMapBounds(SpellGroup group_id) const;
-        void GetSetOfSpellsInSpellGroup(SpellGroup group_id, std::set<uint32>& foundSpells) const;
-        void GetSetOfSpellsInSpellGroup(SpellGroup group_id, std::set<uint32>& foundSpells, std::set<SpellGroup>& usedGroups) const;
+    SpellGroupSpellMapBounds GetSpellGroupSpellMapBounds(SpellGroup group_id) const;
+    void GetSetOfSpellsInSpellGroup(SpellGroup group_id, std::set<uint32>& foundSpells) const;
+    void GetSetOfSpellsInSpellGroup(SpellGroup group_id, std::set<uint32>& foundSpells, std::set<SpellGroup>& usedGroups) const;
 
-        // Spell Group Stack Rules table
-        bool AddSameEffectStackRuleSpellGroups(SpellInfo const* spellInfo, uint32 auraType, int32 amount, std::map<SpellGroup, int32>& groups) const;
-        SpellGroupStackRule CheckSpellGroupStackRules(SpellInfo const* spellInfo1, SpellInfo const* spellInfo2) const;
-        SpellGroupStackRule GetSpellGroupStackRule(SpellGroup groupid) const;
+    // Spell Group Stack Rules table
+    bool AddSameEffectStackRuleSpellGroups(SpellInfo const* spellInfo, uint32 auraType, int32 amount, std::map<SpellGroup, int32>& groups) const;
+    SpellGroupStackRule CheckSpellGroupStackRules(SpellInfo const* spellInfo1, SpellInfo const* spellInfo2) const;
+    SpellGroupStackRule GetSpellGroupStackRule(SpellGroup groupid) const;
 
-        // Spell proc table
-        SpellProcEntry const* GetSpellProcEntry(uint32 spellId) const;
-        static bool CanSpellTriggerProcOnEvent(SpellProcEntry const& procEntry, ProcEventInfo& eventInfo);
+    // Spell proc table
+    SpellProcEntry const* GetSpellProcEntry(uint32 spellId) const;
+    static bool CanSpellTriggerProcOnEvent(SpellProcEntry const& procEntry, ProcEventInfo& eventInfo);
 
-        // Spell bonus data table
-        SpellBonusEntry const* GetSpellBonusData(uint32 spellId) const;
+    // Spell bonus data table
+    SpellBonusEntry const* GetSpellBonusData(uint32 spellId) const;
 
-        // Spell threat table
-        SpellThreatEntry const* GetSpellThreatEntry(uint32 spellID) const;
+    // Spell threat table
+    SpellThreatEntry const* GetSpellThreatEntry(uint32 spellID) const;
 
-        SkillLineAbilityMapBounds GetSkillLineAbilityMapBounds(uint32 spell_id) const;
+    SkillLineAbilityMapBounds GetSkillLineAbilityMapBounds(uint32 spell_id) const;
 
-        PetAura const* GetPetAura(uint32 spell_id, uint8 eff) const;
+    PetAura const* GetPetAura(uint32 spell_id, uint8 eff) const;
 
-        SpellEnchantProcEntry const* GetSpellEnchantProcEvent(uint32 enchId) const;
-        bool IsArenaAllowedEnchancment(uint32 ench_id) const;
+    SpellEnchantProcEntry const* GetSpellEnchantProcEvent(uint32 enchId) const;
+    bool IsArenaAllowedEnchancment(uint32 ench_id) const;
 
-        const std::vector<int32> *GetSpellLinked(int32 spell_id) const;
+    std::vector<int32> const* GetSpellLinked(int32 spell_id) const;
 
-        PetLevelupSpellSet const* GetPetLevelupSpellList(uint32 petFamily) const;
-        PetDefaultSpellsEntry const* GetPetDefaultSpellsEntry(int32 id) const;
+    PetLevelupSpellSet const* GetPetLevelupSpellList(uint32 petFamily) const;
+    PetDefaultSpellsEntry const* GetPetDefaultSpellsEntry(int32 id) const;
 
-        // Spell area
-        SpellAreaMapBounds GetSpellAreaMapBounds(uint32 spell_id) const;
-        SpellAreaForQuestMapBounds GetSpellAreaForQuestMapBounds(uint32 quest_id) const;
-        SpellAreaForQuestMapBounds GetSpellAreaForQuestEndMapBounds(uint32 quest_id) const;
-        SpellAreaForAuraMapBounds GetSpellAreaForAuraMapBounds(uint32 spell_id) const;
-        SpellAreaForAreaMapBounds GetSpellAreaForAreaMapBounds(uint32 area_id) const;
+    // Spell area
+    SpellAreaMapBounds GetSpellAreaMapBounds(uint32 spell_id) const;
+    SpellAreaForQuestMapBounds GetSpellAreaForQuestMapBounds(uint32 quest_id) const;
+    SpellAreaForQuestMapBounds GetSpellAreaForQuestEndMapBounds(uint32 quest_id) const;
+    SpellAreaForAuraMapBounds GetSpellAreaForAuraMapBounds(uint32 spell_id) const;
+    SpellAreaForAreaMapBounds GetSpellAreaForAreaMapBounds(uint32 area_id) const;
 
-        // SpellInfo object management
-        SpellInfo const* GetSpellInfo(uint32 spellId) const { return spellId < GetSpellInfoStoreSize() ?  mSpellInfoMap[spellId] : nullptr; }
-        // Use this only with 100% valid spellIds
-        SpellInfo const* AssertSpellInfo(uint32 spellId) const
-        {
-            ASSERT(spellId < GetSpellInfoStoreSize());
-            SpellInfo const* spellInfo = mSpellInfoMap[spellId];
-            ASSERT(spellInfo);
-            return spellInfo;
-        }
-        uint32 GetSpellInfoStoreSize() const { return mSpellInfoMap.size(); }
+    // SpellInfo object management
+    SpellInfo const* GetSpellInfo(uint32 spellId) const { return spellId < GetSpellInfoStoreSize() ? mSpellInfoMap[spellId] : nullptr; }
+    // Use this only with 100% valid spellIds
+    SpellInfo const* AssertSpellInfo(uint32 spellId) const
+    {
+        ASSERT(spellId < GetSpellInfoStoreSize());
+        SpellInfo const* spellInfo = mSpellInfoMap[spellId];
+        ASSERT(spellInfo);
+        return spellInfo;
+    }
+    uint32 GetSpellInfoStoreSize() const { return mSpellInfoMap.size(); }
 
-    private:
-        SpellInfo* _GetSpellInfo(uint32 spellId) { return spellId < GetSpellInfoStoreSize() ?  mSpellInfoMap[spellId] : nullptr; }
+  private:
+    SpellInfo* _GetSpellInfo(uint32 spellId) { return spellId < GetSpellInfoStoreSize() ? mSpellInfoMap[spellId] : nullptr; }
 
     // Modifiers
-    public:
+  public:
+    // Loading data at server startup
+    void UnloadSpellInfoChains();
+    void LoadSpellTalentRanks();
+    void LoadSpellRanks();
+    void LoadSpellRequired();
+    void LoadSpellLearnSkills();
+    void LoadSpellLearnSpells();
+    void LoadSpellTargetPositions();
+    void LoadSpellGroups();
+    void LoadSpellGroupStackRules();
+    void LoadSpellProcs();
+    void LoadSpellBonuses();
+    void LoadSpellThreats();
+    void LoadSkillLineAbilityMap();
+    void LoadSpellPetAuras();
+    void LoadSpellEnchantProcData();
+    void LoadSpellLinked();
+    void LoadPetLevelupSpellMap();
+    void LoadPetDefaultSpells();
+    void LoadSpellAreas();
+    void LoadSpellInfoStore();
+    void UnloadSpellInfoStore();
+    void UnloadSpellInfoImplicitTargetConditionLists();
+    void UnloadSpellAreaConditions();
+    void LoadSpellInfoCustomAttributes();
+    void LoadSpellInfoCorrections();
+    void LoadSpellInfoSpellSpecificAndAuraState();
+    void LoadSpellInfoDiminishing();
+    void LoadSpellInfoImmunities();
 
-        // Loading data at server startup
-        void UnloadSpellInfoChains();
-        void LoadSpellTalentRanks();
-        void LoadSpellRanks();
-        void LoadSpellRequired();
-        void LoadSpellLearnSkills();
-        void LoadSpellLearnSpells();
-        void LoadSpellTargetPositions();
-        void LoadSpellGroups();
-        void LoadSpellGroupStackRules();
-        void LoadSpellProcs();
-        void LoadSpellBonuses();
-        void LoadSpellThreats();
-        void LoadSkillLineAbilityMap();
-        void LoadSpellPetAuras();
-        void LoadSpellEnchantProcData();
-        void LoadSpellLinked();
-        void LoadPetLevelupSpellMap();
-        void LoadPetDefaultSpells();
-        void LoadSpellAreas();
-        void LoadSpellInfoStore();
-        void UnloadSpellInfoStore();
-        void UnloadSpellInfoImplicitTargetConditionLists();
-        void UnloadSpellAreaConditions();
-        void LoadSpellInfoCustomAttributes();
-        void LoadSpellInfoCorrections();
-        void LoadSpellInfoSpellSpecificAndAuraState();
-        void LoadSpellInfoDiminishing();
-        void LoadSpellInfoImmunities();
-
-    private:
-        SpellDifficultySearcherMap mSpellDifficultySearcherMap;
-        SpellChainMap              mSpellChains;
-        SpellsRequiringSpellMap    mSpellsReqSpell;
-        SpellRequiredMap           mSpellReq;
-        SpellLearnSkillMap         mSpellLearnSkills;
-        SpellLearnSpellMap         mSpellLearnSpells;
-        SpellTargetPositionMap     mSpellTargetPositions;
-        SpellSpellGroupMap         mSpellSpellGroup;
-        SpellGroupSpellMap         mSpellGroupSpell;
-        SpellGroupStackMap         mSpellGroupStack;
-        SameEffectStackMap         mSpellSameEffectStack;
-        SpellProcMap               mSpellProcMap;
-        SpellBonusMap              mSpellBonusMap;
-        SpellThreatMap             mSpellThreatMap;
-        SpellPetAuraMap            mSpellPetAuraMap;
-        SpellLinkedMap             mSpellLinkedMap;
-        SpellEnchantProcEventMap   mSpellEnchantProcEventMap;
-        SpellAreaMap               mSpellAreaMap;
-        SpellAreaForQuestMap       mSpellAreaForQuestMap;
-        SpellAreaForQuestMap       mSpellAreaForQuestEndMap;
-        SpellAreaForAuraMap        mSpellAreaForAuraMap;
-        SpellAreaForAreaMap        mSpellAreaForAreaMap;
-        SkillLineAbilityMap        mSkillLineAbilityMap;
-        PetLevelupSpellMap         mPetLevelupSpellMap;
-        PetDefaultSpellsMap        mPetDefaultSpellsMap;           // only spells not listed in related mPetLevelupSpellMap entry
-        SpellInfoMap               mSpellInfoMap;
+  private:
+    SpellDifficultySearcherMap mSpellDifficultySearcherMap;
+    SpellChainMap mSpellChains;
+    SpellsRequiringSpellMap mSpellsReqSpell;
+    SpellRequiredMap mSpellReq;
+    SpellLearnSkillMap mSpellLearnSkills;
+    SpellLearnSpellMap mSpellLearnSpells;
+    SpellTargetPositionMap mSpellTargetPositions;
+    SpellSpellGroupMap mSpellSpellGroup;
+    SpellGroupSpellMap mSpellGroupSpell;
+    SpellGroupStackMap mSpellGroupStack;
+    SameEffectStackMap mSpellSameEffectStack;
+    SpellProcMap mSpellProcMap;
+    SpellBonusMap mSpellBonusMap;
+    SpellThreatMap mSpellThreatMap;
+    SpellPetAuraMap mSpellPetAuraMap;
+    SpellLinkedMap mSpellLinkedMap;
+    SpellEnchantProcEventMap mSpellEnchantProcEventMap;
+    SpellAreaMap mSpellAreaMap;
+    SpellAreaForQuestMap mSpellAreaForQuestMap;
+    SpellAreaForQuestMap mSpellAreaForQuestEndMap;
+    SpellAreaForAuraMap mSpellAreaForAuraMap;
+    SpellAreaForAreaMap mSpellAreaForAreaMap;
+    SkillLineAbilityMap mSkillLineAbilityMap;
+    PetLevelupSpellMap mPetLevelupSpellMap;
+    PetDefaultSpellsMap mPetDefaultSpellsMap; // only spells not listed in related mPetLevelupSpellMap entry
+    SpellInfoMap mSpellInfoMap;
 };
 
 #define sSpellMgr SpellMgr::instance()


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->
### Changes proposed

-  Cherry Picked TCPP
-  Core/Spells: Fix periodic rolling adding bonuses twice
Calculation is now done in CalculateAmount


### Issues addressed
<!-- If your fix has a relating issue, link it below -->

- Closes

### SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

- https://github.com/The-Cataclysm-Preservation-Project/TrinityCore/commit/1fe5563431fc722154f5138c71c69c177cfb3470#diff-a2a2343f2b1620e61594cb8b19343ebddb437f761cb9ff6a6ea26f36b038efa5

- Thank you for collaborating with the project.
- For an efficient working methodology.
- It is obvious to make long pull request, unless it is necessary.
- A short pull request would be easy to test and approve.
